### PR TITLE
feat(sidecar): add signed Go 1.27 policy decision service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,36 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  sidecar:
+    name: Go 1.27 Sidecar
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: services/sidecar
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.27.x"
+          cache: false
+
+      - name: Verify formatting
+        run: make fmt-check
+
+      - name: Vet
+        run: make vet
+
+      - name: Test with race detector
+        run: make test-race
+
+      - name: Build service and policy tools
+        run: make build tools
+
   oss:
     name: OSS Build + Typecheck + Test + Example
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,12 @@ jobs:
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.27.x"
+          cache: false
+
       - name: Verify Node and npm
         run: |
           node --version
@@ -64,6 +70,10 @@ jobs:
 
       - name: Example smoke test
         run: pnpm --filter "@aegisora/example-langgraph-agent-governance" test
+
+      - name: Validate Go sidecar
+        working-directory: services/sidecar
+        run: make fmt-check vet test-race build tools
 
       - name: Validate release version
         shell: bash

--- a/.github/workflows/security-readiness.yml
+++ b/.github/workflows/security-readiness.yml
@@ -112,9 +112,10 @@ jobs:
           AUDIT_SCRIPT: |
             const fs = require("fs");
             const manifest = process.argv[1];
+            const expectedVersion = process.argv[2];
             const pkg = JSON.parse(fs.readFileSync(manifest, "utf8"));
-            if (pkg.version !== "2.0.0") {
-              throw new Error(`Expected 2.0.0, got ${pkg.version}`);
+            if (pkg.version !== expectedVersion) {
+              throw new Error(`Expected ${expectedVersion}, got ${pkg.version}`);
             }
             const keys = ["name", "version", "license", "repository", "bugs", "homepage", "exports", "types"];
             for (const key of keys) {
@@ -148,6 +149,8 @@ jobs:
           )
           temp_root="$(mktemp -d)"
           trap 'rm -rf "$temp_root"' EXIT
+          expected_version="$(node -p "require('./core/packages/core/package.json').version")"
+          test -n "$expected_version"
 
           for package in "${packages[@]}"; do
             dir="core/packages/$package"
@@ -165,7 +168,7 @@ jobs:
             tar -xzf "$tarball" -C "$extract"
             manifest="$extract/package/package.json"
             test -s "$manifest"
-            node -e "$AUDIT_SCRIPT" "$manifest"
+            node -e "$AUDIT_SCRIPT" "$manifest" "$expected_version"
           done
           echo "PASS all public package tarballs"
 
@@ -174,12 +177,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if grep -R -n -I -E \
+          if git grep -n -I -E \
             "(BEGIN (RSA|OPENSSH|EC|DSA) PRIVATE KEY|AKIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{20,}|npm_[A-Za-z0-9]{20,})" \
-            --exclude-dir=.git \
-            --exclude-dir=node_modules \
-            --exclude='*.lock' \
-            .; then
+            -- . \
+            ":(exclude,glob)**/*.lock" \
+            ":(exclude,glob)*.lock"; then
             echo "FAIL possible secret material detected"
             exit 1
           fi

--- a/REPOSITORY_INVESTIGATION.md
+++ b/REPOSITORY_INVESTIGATION.md
@@ -1,0 +1,469 @@
+# Repository Investigation: Go Enforcement Sidecar and FastAPI Control Plane
+
+## Proposed issue title
+
+`RFC/EPIC: Complete the Go enforcement sidecar and FastAPI governance control plane`
+
+## Investigation verdict
+
+**Proceed with the proposal, using the boundaries and delivery order in this document.**
+
+The proposal remains correct after rebasing onto the latest upstream `main`, including Aegisora `2.0.0` and the subsequent delegation and collaboration hardening. The `v1alpha1` OpenAPI contract and semantic fixture corpus are unchanged from `v1.5.0`, so the Go implementation remains contract-compatible. Meanwhile, the TypeScript runtime now has a canonical tool authority, scoped single-use authorization receipts, explicit delegated-agent capabilities, stronger governance, correlation and collaboration boundaries, canonical decision/evidence records, and the first Go 1.27 sidecar vertical slice. These additions strengthen the proposal because there is now a real cross-language contract and a clearer runtime authority model around which the data plane and control plane can converge.
+
+The important qualification is that the current Go service is a **decision sidecar**, not yet a complete **enforcement sidecar**. It validates an intent and safely returns `ALLOW`, `BLOCK`, or `ESCALATE`, but it cannot yet prevent a caller from ignoring that answer and calling an upstream directly. The next slice must add a controlled upstream proxy and deployment isolation before this can be called a hard enforcement boundary.
+
+## Executive summary
+
+Aegisora should use:
+
+- a local **Go sidecar** as the low-latency enforcement/data plane;
+- a **FastAPI service** as the identity, policy, review, and audit control plane;
+- **PostgreSQL** as the authoritative durable store;
+- the existing **TypeScript SDK/runtime** as the developer integration and agent-lifecycle layer;
+- one versioned contract and semantic fixture corpus shared by every language.
+
+The central security invariant is:
+
+> No governed capability may cross the execution boundary until the canonical enforcement path has produced `ALLOW`, and neither `BLOCK` nor `ESCALATE` may cause an upstream side effect.
+
+A decision endpoint alone does not enforce that invariant. The Go process must ultimately own the only reachable path to protected tool, provider, or API destinations.
+
+## What was rechecked
+
+The investigation was repeated against the post-`2.0.0` upstream `main`, covering:
+
+- `contracts/openapi/v1alpha1/openapi.yaml` — cross-language wire contracts;
+- `contracts/conformance/v1alpha1/semantic-fixtures.json` — semantic invariants;
+- `core/packages/core` — canonical decision and evidence types;
+- `core/packages/runtime` — identity, permissions, enforcement, execution, and finalization;
+- `core/packages/audit` — canonical evidence persistence;
+- `core/main.py` and `core/interceptor.py` — the Python/FastAPI prototype;
+- `services/sidecar` — the Go 1.27 implementation and tests;
+- CI and release workflows — required cross-language checks.
+
+### Findings
+
+1. **The control-plane/data-plane split is the right design.** FastAPI is a good home for management workflows and durable state. Go fits a small local process with bounded memory, explicit concurrency, predictable startup, and a narrow attack surface.
+2. **The repository now owns a usable shared contract.** Work should extend `v1alpha1`, not invent another sidecar-specific request model.
+3. **The TypeScript runtime has valuable canonical behavior.** Aegisora `2.0.0` establishes `ToolRegistry` as the single canonical runtime tool authority, uses scoped single-use authorization receipts, removes legacy runtime authority implementations, and locks down governance and correlation identity boundaries. The latest upstream hardening also adds expiring, revocable, single-use delegation capabilities with scope containment and enforces collaboration task ownership. These semantics should be migration inputs and conformance references, not silently duplicated with different meanings.
+4. **The Python interceptor is a prototype, not a production data plane.** It trusts caller-provided tenant data, stores policy in memory, and returns a decision without controlling the downstream call. It should become the control plane instead of competing with Go for enforcement authority.
+5. **Identity is the largest remaining security gap.** `agent_claim` is only a claim. The local transport must authenticate a workload, after which the sidecar derives or verifies canonical tenant/agent identity.
+6. **The first Go slice is fail closed.** No policy, invalid signature, expiry, scope mismatch, malformed intent, request-ID conflict, and audit append failure cannot produce a successful allow response.
+7. **Durability and hard enforcement remain open.** Audit and idempotency are bounded in-memory stores, policy is loaded from a local file, and `ALLOW` does not yet perform an upstream call.
+
+## Current and target architecture
+
+Today:
+
+```text
+TypeScript AgentRuntime
+  -> in-process identity, permission, policy, security and risk
+  -> canonical decision and evidence records
+  -> current tool/provider adapters
+
+Python FastAPI prototype
+  -> in-memory tenant policy
+  -> ALLOW/BLOCK response
+  -> no durable authority or controlled execution path
+
+Go 1.27 sidecar
+  -> strict v1alpha1 intent decoding
+  -> signed policy verification and atomic activation
+  -> deterministic BLOCK > ESCALATE > ALLOW evaluation
+  -> idempotent decision and bounded audit event
+  -> no upstream proxy yet
+```
+
+Target:
+
+```text
+Agent / TypeScript SDK
+          |
+          | authenticated local execution intent
+          v
++------------------------------------------------+
+| Go sidecar                                    |
+| workload identity -> canonical capability      |
+| strict validation -> active policy snapshot    |
+| permission/policy/security/risk evaluation     |
+| audit intent + decision                        |
+| controlled proxy only when decision == ALLOW   |
++----------------------+-------------------------+
+                       |
+             ALLOW     |     BLOCK / ESCALATE
+                       |              |
+                       v              v
+              allowlisted upstream   no side effect
+
+FastAPI control plane
+  -> PostgreSQL tenants, identities and capabilities
+  -> immutable policy versions and signed bundles
+  -> sidecar registration and bundle distribution
+  -> audit ingestion, evidence queries, and reviews
+```
+
+### Authority boundaries
+
+- FastAPI is authoritative for desired identity, capability, policy, route, review, and revocation state.
+- PostgreSQL is the durable system of record.
+- A sidecar is authoritative for enforcing one verified snapshot for one request.
+- The TypeScript SDK constructs intents but cannot assert trusted identity or override a sidecar decision.
+- Request `input`, `context`, headers, and caller-provided tenant/agent values are untrusted.
+- The website is a management client, never a runtime policy authority.
+- Redis may accelerate disposable work but cannot be the only policy or evidence authority.
+
+## Implemented Go 1.27 vertical slice
+
+### Contract types and validation
+
+The model follows the repository's `v1alpha1` contract:
+
+```go
+type ExecutionIntent struct {
+    RequestID         string                     `json:"request_id"`
+    CorrelationID     string                     `json:"correlation_id,omitempty"`
+    AgentClaim        string                     `json:"agent_claim"`
+    CapabilityRequest CapabilityRequest          `json:"capability_request"`
+    Input             map[string]json.RawMessage `json:"input"`
+    Context           map[string]json.RawMessage `json:"context"`
+}
+
+type Decision string
+
+const (
+    DecisionAllow    Decision = "ALLOW"
+    DecisionBlock    Decision = "BLOCK"
+    DecisionEscalate Decision = "ESCALATE"
+)
+
+func (decision Decision) Allowed() bool {
+    return decision == DecisionAllow
+}
+```
+
+`allowed` is constructed from `decision`; it is never independently treated as policy truth. This prevents an unsafe response such as `{"decision":"BLOCK","allowed":true}`.
+
+The HTTP boundary requires JSON, limits body size, rejects unknown fields and trailing values, and validates string sizes plus required object fields before evaluation.
+
+### Signed policy snapshots
+
+Policy bundles are hashed and signed with Ed25519. The digest covers bundle ID, scope, version, expiry, and normalized policy:
+
+```go
+payload := struct {
+    BundleID  string
+    Scope     domain.PolicyScope
+    Version   string
+    ExpiresAt time.Time
+    Policy    any
+}{
+    BundleID:  bundle.BundleID,
+    Scope:     bundle.Scope,
+    Version:   bundle.Version,
+    ExpiresAt: bundle.ExpiresAt.UTC(),
+    Policy:    normalizedPolicy,
+}
+
+encoded, _ := json.Marshal(payload)
+sum := sha256.Sum256(encoded)
+digest := "sha256:" + hex.EncodeToString(sum[:])
+```
+
+The sidecar receives only a public verification key. Production private-key custody belongs in the control plane or a dedicated signer. Changing any protected field after signing makes activation fail.
+
+Activation compiles before acquiring the write lock and atomically swaps a deeply cloned snapshot. Readers see a complete old or new version, and callers cannot mutate live rules through returned slices, raw JSON buffers, or nested risk signals.
+
+### Deterministic policy behavior
+
+Every match field is optional and behaves as a wildcard. All matching rules are considered with this precedence:
+
+```text
+BLOCK > ESCALATE > ALLOW
+```
+
+Example:
+
+```json
+{
+  "default_decision": "BLOCK",
+  "rules": [
+    {
+      "agent_claim": "agent:demo",
+      "capability": "provider.generate",
+      "provider": "openai",
+      "model": "gpt-test",
+      "route": "/v1/chat/completions",
+      "decision": "ALLOW",
+      "reason_code": "OPENAI_ALLOWED",
+      "risk": {
+        "score": 10,
+        "level": "LOW",
+        "signals": []
+      }
+    }
+  ]
+}
+```
+
+A broad allow cannot defeat a narrower matching block merely because it appears first.
+
+### Idempotent decisions
+
+The engine hashes the canonical JSON intent and associates it with `request_id`:
+
+```go
+if cached, exists := engine.cached(intent.RequestID); exists {
+    if cached.intentDigest != intentDigest {
+        return engine.finish(ctx, intent, correlationID, snapshot, policy.Evaluation{
+            Decision:   domain.DecisionBlock,
+            ReasonCode: "REQUEST_ID_CONFLICT",
+            Risk:       domain.Risk{Score: 100, Level: "HIGH"},
+        }, now, hasPolicy)
+    }
+    if cacheMatchesPolicy(cached, snapshot, hasPolicy) {
+        return cached.envelope, nil
+    }
+}
+```
+
+Calls sharing a request ID are serialized with a reference-counted keyed mutex. Concurrent identical calls receive the exact same decision and create one decision audit event while the active policy version and digest remain unchanged. A policy change, removal, or expiry forces reevaluation, so a cached `ALLOW` cannot survive loss of its authorizing policy. Reusing the ID for different input fails closed. Cached envelopes are deep-copied at the storage boundary so a caller cannot mutate stored risk signals. This cache is bounded and in memory, so proxy execution needs durable or upstream-aware idempotency before retries can span restarts.
+
+### Audit correlation and readiness
+
+Every successfully returned decision is paired with an audit event containing event, request, correlation, decision, and policy identifiers. The sink is currently a bounded in-memory ring. Events and their JSON payload bytes are copied both when appended and when read, preventing callers from mutating stored evidence through shared references. If append itself fails, the engine does not return a successful decision response. A durable write-ahead log and idempotent exporter remain required.
+
+Liveness means the process serves diagnostics. Readiness means a valid, unexpired policy is active:
+
+```text
+no configured bundle -> health 200, readiness 503, evaluation BLOCK
+valid signed bundle  -> readiness 200
+expired bundle       -> readiness 503, evaluation BLOCK
+```
+
+## Request and response examples
+
+```http
+POST /v1alpha1/execution/intent HTTP/1.1
+Content-Type: application/json
+
+{
+  "request_id": "req-01J8YQ8R7V",
+  "correlation_id": "trace-01J8YQ8R7V",
+  "agent_claim": "agent:demo",
+  "capability_request": {
+    "capability": "provider.generate",
+    "provider": "openai",
+    "model": "gpt-test",
+    "route": "/v1/chat/completions"
+  },
+  "input": {},
+  "context": {}
+}
+```
+
+```json
+{
+  "decision_id": "8d01dfee-58c5-43ec-a0c3-d2ba5b05e999",
+  "request_id": "req-01J8YQ8R7V",
+  "correlation_id": "trace-01J8YQ8R7V",
+  "decision": "ALLOW",
+  "allowed": true,
+  "reason_code": "OPENAI_ALLOWED",
+  "risk": {"score": 10, "level": "LOW"},
+  "policy_version": "42",
+  "policy_digest": "sha256:8a5f...",
+  "evaluated_at": "2026-08-29T12:00:00Z"
+}
+```
+
+A syntactically valid intent receives a decision envelope even when blocked. Transport/schema failures receive an HTTP error. This separates policy outcomes from malformed network input.
+
+## Required next slice: controlled upstream proxy
+
+This is the next priority because it turns advice into enforcement. The proxy must:
+
+1. Resolve upstreams only from signed policy and trusted configuration.
+2. Reject arbitrary caller-provided URLs, hosts, schemes, and redirect targets.
+3. Authenticate and validate the workload before evaluation.
+4. Use one immutable policy snapshot for evaluation and route selection.
+5. Create audit evidence before or around execution as required by policy.
+6. Make zero upstream requests for `BLOCK`, `ESCALATE`, malformed input, expired policy, or unknown identity/capability/route.
+7. Apply explicit connect, header, body, response, and total deadlines.
+8. Define redirect, streaming, cancellation, retry, and response-size behavior.
+9. Bind retries to idempotency so ambiguous failures cannot duplicate side effects.
+10. Be deployed so the workload cannot directly reach the protected destination.
+
+The critical adversarial test uses a counting upstream:
+
+```go
+var upstreamCalls atomic.Int64
+
+upstream := httptest.NewServer(http.HandlerFunc(
+    func(w http.ResponseWriter, r *http.Request) {
+        upstreamCalls.Add(1)
+        w.WriteHeader(http.StatusOK)
+    },
+))
+
+// ALLOW increments once.
+// BLOCK, ESCALATE, bad policy, identity mismatch, and route mismatch
+// leave upstreamCalls unchanged.
+```
+
+Passing that test is necessary but not sufficient: deployment/network policy must prevent direct access around the proxy.
+
+## FastAPI control-plane scope
+
+FastAPI owns management state and workflows, not the synchronous hot path for every action. It must:
+
+- authenticate operators and sidecars separately and enforce tenant-aware RBAC;
+- manage tenants, workload identities, agents, capabilities, models, and routes;
+- validate policies and compile a normalized sidecar representation;
+- persist immutable policy versions in PostgreSQL;
+- hash, sign, publish, revoke, and intentionally roll back bundles;
+- serve updates with authenticated conditional polling initially;
+- rotate signing keys without an unverified transition window;
+- ingest idempotent audit batches and expose evidence queries;
+- persist escalation requests and reviewer actions;
+- issue short-lived, single-use approval tokens bound to the original intent digest, identity, capability, policy version, and expiry.
+
+It may provide a reference evaluator for conformance, but should not be a required network hop for deterministic local rules.
+
+## Human-review semantics
+
+`ESCALATE` means “do not execute yet,” not “allow and notify.”
+
+1. The sidecar records the escalation and original intent digest.
+2. FastAPI creates a tenant-scoped pending review.
+3. An authorized reviewer approves or denies it.
+4. Approval issues a short-lived, single-use token bound to the exact intent and policy version.
+5. The client resubmits through the sidecar.
+6. The sidecar validates the token and rechecks non-overridable safety rules.
+
+Approval never directly invokes the upstream or bypasses the sidecar.
+
+## Failure semantics
+
+| Condition | Required behavior |
+| --- | --- |
+| No policy loaded | not ready; `BLOCK` execution |
+| Control plane unavailable with valid unexpired snapshot | continue last-known-good and report degraded state |
+| Snapshot expired, malformed, incompatible, or unverifiable | fail closed |
+| Unknown workload identity or capability/route | `BLOCK` and audit |
+| Required remote analysis unavailable | explicit `BLOCK` or `ESCALATE`; never implicit allow |
+| Duplicate ID with identical intent | return the compatible original result |
+| Duplicate ID with different intent | conflict/`BLOCK` and audit |
+| Audit export unavailable | retain locally within a configured durable bound |
+| Required durability unavailable for high-impact action | fail closed according to policy |
+| Sidecar unavailable | SDK returns enforcement unavailable; no direct fallback |
+| Unexpected older policy | reject unless authenticated rollback authorizes it |
+
+## Security requirements
+
+- Prefer a filesystem-permissioned Unix domain socket for the local API.
+- Bind loopback TCP only when explicitly configured and secure it independently.
+- Use mTLS between sidecars and the control plane.
+- Derive tenant/workload identity from credentials or pinned configuration.
+- Treat `agent_claim` as a claim that must match canonical identity.
+- Prevent metadata from overriding trusted provider, model, route, or policy fields.
+- Source destinations from signed configuration and constrain redirects/DNS behavior.
+- Redact credentials and sensitive input from logs and evidence.
+- Support key rotation, revocation, and intentional rollback.
+- Bind approvals to one intent and prevent replay.
+- Bound request/response size, decompression, concurrency, rate, and deadlines.
+- Preserve request, correlation, decision, evidence, and policy identifiers end to end.
+
+## Proposed PR sequence
+
+### PR 1 — Go decision-sidecar foundation
+
+Status: implemented on the current feature branch.
+
+- Go 1.27 service and container build;
+- `v1alpha1` types and strict decoding;
+- all three decisions and deny-overrides evaluation;
+- signed bundle verification and atomic activation;
+- idempotent decisions and bounded audit;
+- readiness and active-policy metadata;
+- shared-fixture, integration, and race tests;
+- CI/release validation and local signing tools.
+
+### PR 2 — Controlled proxy and no-side-effect proof
+
+- signed/pinned upstream route table;
+- controlled execute/proxy endpoint;
+- redirect, timeout, cancellation, streaming, and size policy;
+- counting-upstream adversarial tests;
+- deployment proof that protected upstreams are isolated.
+
+### PR 3 — Workload identity
+
+- Unix-domain-socket transport by default;
+- peer or pinned workload authentication;
+- canonical tenant/agent resolution;
+- claim-mismatch and metadata-confusion tests.
+
+This can be combined with PR 2 if identity is required to define the proxy API cleanly, while remaining a separately reviewable concern in code.
+
+### PR 4 — Control-plane policy distribution
+
+- authenticated FastAPI bundle endpoint;
+- conditional polling with bounded backoff;
+- monotonic version and authorized rollback rules;
+- key rotation/revocation;
+- atomic last-known-good persistence and outage tests.
+
+### PR 5 — Durable audit and escalation
+
+- local write-ahead log and idempotent batches;
+- persistent review state;
+- request-bound single-use approval tokens;
+- restart, replay, and partial-delivery tests.
+
+### PR 6 — TypeScript distributed mode
+
+- typed sidecar client and correlation propagation;
+- clear blocked/escalated/unavailable errors;
+- no direct fallback in distributed mode;
+- cross-language end-to-end conformance.
+
+## Epic acceptance criteria
+
+- [ ] One OpenAPI contract validates Python, Go, and TypeScript models.
+- [ ] Shared semantic fixtures fail CI on implementation drift.
+- [x] Go verifies and atomically activates a scoped, signed, expiring bundle.
+- [x] Go returns all three decisions with correlation and policy evidence.
+- [x] Missing/invalid/expired policy and scope mismatch fail closed.
+- [x] Concurrent identical IDs produce one stable decision and audit event.
+- [ ] Only `ALLOW` reaches a controlled test upstream.
+- [ ] Deployment prevents direct workload access to that upstream.
+- [ ] Workload and operator identities are authenticated independently.
+- [ ] FastAPI stores immutable policies and authoritative state in PostgreSQL.
+- [ ] Policy polling tolerates outage only while last-known-good remains valid.
+- [ ] Audit delivery is durable and idempotent across restart/outage.
+- [ ] Approved escalations are single-use, expire, and return through the sidecar.
+- [ ] TypeScript cannot silently bypass distributed enforcement.
+- [ ] mTLS, RBAC, key lifecycle, redaction, route allowlisting, limits, and rollback are validated.
+- [ ] Latency, throughput, and failure benchmarks are documented.
+
+## Non-goals for the first enforcement release
+
+- a general-purpose service mesh;
+- transparent interception of every network protocol;
+- a new unrestricted policy language;
+- arbitrary sidecar plugins;
+- multi-region active/active control plane;
+- a production administration UI;
+- optimization without representative profiling.
+
+## Final proposal verdict
+
+The proposal fits the updated repository provided these distinctions remain explicit:
+
+1. the implemented Go slice makes trustworthy decisions but does not yet own side effects;
+2. authenticated workload identity and controlled routing are required, not optional hardening;
+3. FastAPI owns governance state/publication, while Go enforces a verified snapshot;
+4. TypeScript remains the integration layer and cannot fall back to direct execution;
+5. one contract, fixture corpus, and decision vocabulary govern all implementations.
+
+The recommended immediate continuation is PR 2: controlled upstream proxying plus adversarial proof that every non-`ALLOW` path produces zero upstream calls.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -171,13 +171,16 @@ Governance decisions should preserve identity, capability, decision, reason, ris
 
 ## 6. Current Engineering Bottlenecks
 
-One open architectural question is whether the highest-throughput network routing layer should eventually be decoupled into a dedicated **Go-based microservice**, while policy management and governance semantics remain in the existing control-plane implementation.
+The repository now evaluates this split through an initial **Go 1.27 decision sidecar** under `services/sidecar`, while policy management and governance semantics are intended to move into a **FastAPI control plane**.
 
 The benefit would be high-throughput routing and a clearer data-plane/control-plane separation.
 
-THe trade-off is additional operational complexity and the requirement to preserve identity, policy propagation, and audit correlation across the service boundary.
+The trade-off is additional operational complexity and the requirement to preserve identity, policy propagation, and audit correlation across the service boundary.
 
-This remains an open engineering decision rather than a finalized architecture.
+The decision API, signed local policy activation, and deterministic evaluator are implemented. The controlled upstream proxy, authenticated workload boundary, remote bundle distribution, and durable audit path remain open engineering work; until those land, the Go service is not yet the complete enforcement boundary.
+
+See [Go Sidecar and FastAPI Control Plane](./architecture/go-sidecar-fastapi-control-plane.md)
+for a detailed explanation and a concrete proposal for evaluating this split.
 
 ---
 

--- a/docs/architecture/go-sidecar-fastapi-control-plane.md
+++ b/docs/architecture/go-sidecar-fastapi-control-plane.md
@@ -1,0 +1,706 @@
+# Go Sidecar and FastAPI Control Plane
+
+## Purpose
+
+This document explains the architecture that exists in this repository and turns the open Go-service question in [`docs/ARCHITECTURE.md`](../ARCHITECTURE.md) into a concrete proposal.
+
+It is a target-architecture proposal, not a description of already implemented production behavior. The repository now contains the first Go decision-sidecar vertical slice under `services/sidecar`; it does not yet contain the controlled upstream proxy or a durable FastAPI control plane.
+
+## The Architecture in Plain Language
+
+Aegisora is intended to sit between an AI agent and anything on which that agent can cause a side effect: a tool, model provider, API, database, shell, or another agent.
+
+The agent supplies an **execution intent**: “I want to perform this action with these arguments.” Aegisora treats that intent as untrusted. It resolves the real identity and capability, evaluates policy and risk, and produces one of three outcomes:
+
+- `ALLOW`: the governed action may proceed through the controlled path.
+- `BLOCK`: the action must stop and no downstream side effect may occur.
+- `ESCALATE`: the action must stop until an authorized human-review workflow explicitly approves it.
+
+This is what “zero-trust runtime governance” means in this repository. It does not mean that every request is rejected. It means no identity, capability, or request is implicitly trusted, and no governed action is executed without an explicit decision.
+
+The most important rule is therefore:
+
+> Enforcement must happen before the side effect, on a path the caller cannot bypass.
+
+Logging a decision after a tool has run, or returning a decision that the caller is free to ignore, does not provide this security boundary.
+
+## What Exists Today
+
+The repository currently contains four major areas:
+
+### Go decision sidecar
+
+`services/sidecar` implements the shared `v1alpha1` execution-intent and decision contracts with Go 1.27. It strictly validates requests, verifies and atomically activates Ed25519-signed policy bundles, evaluates deterministic deny-overrides rules, records correlated decisions in a bounded audit sink, and exposes policy-backed readiness.
+
+This is currently a decision service, not yet the complete hard enforcement boundary: it does not proxy approved upstream requests, authenticate the local workload transport, poll the FastAPI control plane, or durably export audit evidence.
+
+### TypeScript runtime and SDK
+
+The pnpm workspace under `core/packages` is the main implementation. Its packages separate shared contracts, runtime orchestration, policy, security, audit, observability, storage, plugins, and the public SDK.
+
+Within `@aegisora/runtime`, `AgentRuntime` owns the canonical runtime objects: the agent registry, tool registry, permission engine, enforcement gate, provider gateway, lifecycle, and evidence stores. Tool and provider calls are designed to pass through `EnforcementGate` before execution. Private capability tokens make direct access to the underlying tool/provider execution paths more difficult.
+
+The effective runtime flow is:
+
+```text
+SDK / protected agent
+        |
+        v
+TypeScript AgentRuntime
+        |
+        +--> canonical agent and capability lookup
+        +--> permission -> policy -> security -> risk
+        +--> ALLOW / BLOCK / ESCALATE
+        +--> audit decision
+        |
+        +--> provider/tool execution only after ALLOW
+```
+
+The repository also contains a staged `GovernanceEngine` that expresses the conceptual evaluation pipeline. Aegisora `2.0.0` established `ToolRegistry` as the single canonical tool authority, added scoped single-use authorization receipts, removed legacy runtime authority implementations, and hardened governance and correlation boundaries. Subsequent upstream work adds expiring and revocable delegated-agent capabilities, scope-containment checks, sibling isolation, and collaboration task ownership. The sidecar must preserve those canonical identity, capability, delegation, authorization, ownership, and correlation semantics at the process boundary rather than establish a competing authority.
+
+### Python FastAPI reference interceptor
+
+`core/interceptor.py` is a small, transport-neutral reference interceptor with an in-memory tenant policy store. `core/main.py` exposes it through FastAPI at `POST /intercept`.
+
+It demonstrates a useful initial contract: validate a request, resolve a tenant policy, authorize a tool, and return a correlated decision. However, it is only a prototype:
+
+- it supports `ALLOW` and `BLOCK`, but not `ESCALATE`;
+- it trusts a caller-supplied `tenant_id` instead of authenticating a workload;
+- policy and decisions are in memory;
+- it returns a routing hint but does not enforce the downstream side effect;
+- it is currently described as a Python “data plane,” not as a control plane.
+
+The proposal below changes the responsibility of this Python service. FastAPI becomes the management/control plane; the Go sidecar becomes the local, high-throughput enforcement/data plane.
+
+### Next.js website and documentation
+
+`website` is the public UI. It is not, and must not become, an authority for runtime identity or policy decisions. `docs` records the target architecture, security invariants, and architectural decisions.
+
+## Why Split the System?
+
+A control plane and a data plane optimize for different work.
+
+| Plane | Primary job | Desired properties |
+| --- | --- | --- |
+| FastAPI control plane | Manage identities, policies, policy versions, reviews, and audit records | Expressive domain logic, safe administration, durable storage |
+| Go sidecar data plane | Intercept and enforce every governed action close to the workload | Low latency, bounded resource use, easy deployment, fail-closed behavior |
+
+The split removes policy administration and database work from the hot request path. It also allows each agent workload to talk to a local enforcement process instead of making every action depend on a remote management API.
+
+The split is useful only if it preserves one logical authority:
+
+- the control plane is authoritative for **desired policy and identity state**;
+- a sidecar is authoritative for **enforcing the last valid policy snapshot for its workload**;
+- the agent, SDK, website, and request metadata are never security authorities.
+
+## Proposed Target Architecture
+
+```mermaid
+flowchart LR
+    A["Agent / TypeScript SDK"] -->|local intent| G["Go sidecar<br/>data plane"]
+    G --> I["Authenticate workload<br/>resolve canonical identity"]
+    I --> E["Evaluate active<br/>policy bundle"]
+    E --> D{"Decision"}
+    D -->|ALLOW| U["Controlled upstream<br/>tool/provider/API"]
+    D -->|BLOCK| X["No side effect"]
+    D -->|ESCALATE| H["Human review queue<br/>no side effect"]
+    G -->|audit batches| C["FastAPI control plane"]
+    C --> P[(PostgreSQL)]
+    C -->|signed, versioned<br/>policy bundles| G
+    C --> R["Admin / review API"]
+```
+
+### Go sidecar responsibilities
+
+The Go service is the policy-enforcement point next to the governed workload. It should:
+
+1. Listen on a Unix domain socket by default, with loopback TCP as an explicit alternative.
+2. Authenticate the calling workload and derive tenant and agent identity from credentials or sidecar configuration. A payload field alone is never proof of identity.
+3. Validate size, shape, content type, deadlines, and canonical capability names before evaluating a request.
+4. Atomically load a signed, versioned policy bundle obtained from the control plane.
+5. Evaluate deterministic permission, policy, security, and risk rules locally.
+6. Apply deny-overrides precedence and return exactly one of `ALLOW`, `BLOCK`, or `ESCALATE`.
+7. Prevent the side effect on `BLOCK` and `ESCALATE`.
+8. On `ALLOW`, either proxy the request to an allowlisted upstream or issue a short-lived, request-bound authorization token to an enforcement-aware gateway. Proxy mode is the preferred hard boundary.
+9. Write a correlated decision record to a local bounded write-ahead buffer and deliver audit events to the control plane in batches.
+10. Expose liveness, readiness, metrics, and build/policy version information.
+
+The sidecar must not expose policy administration, accept arbitrary upstream URLs, silently downgrade policy versions, or call a protected upstream before the decision is final.
+
+### FastAPI control-plane responsibilities
+
+The FastAPI service owns management and governance state. It should:
+
+1. Authenticate operators and sidecars separately and enforce tenant-scoped authorization.
+2. Manage tenants, workload/agent identities, capabilities, routes, and policy documents.
+3. Validate and compile policy documents into a normalized, immutable policy bundle understood by Go.
+4. Version, hash, sign, publish, and revoke bundles.
+5. Register sidecars and serve bundle updates through polling initially; a streaming transport can be added later without changing policy semantics.
+6. Accept idempotent audit-event batches and persist/query decision evidence.
+7. Create and resolve human-review requests for `ESCALATE` decisions.
+8. Issue a short-lived, single-use approval token bound to the original intent digest, identity, capability, and policy version when a review is approved.
+9. Store authoritative data in PostgreSQL. Redis may be used for disposable caching or queues, but not as the only policy authority.
+
+The control plane should provide a reference evaluator for conformance tests, but it should not be on the normal per-request hot path. A rule that requires a remote check must declare that dependency explicitly and fail closed or escalate when the check is unavailable.
+
+### TypeScript runtime and SDK responsibilities
+
+The existing TypeScript packages remain useful as the developer integration and agent-lifecycle layer. They should:
+
+- turn tool/provider actions into the shared execution-intent contract;
+- call the local Go sidecar for governed execution;
+- preserve request and correlation identifiers;
+- never fall back to an ungoverned direct provider/tool call when the sidecar is unavailable;
+- retain public SDK ergonomics while removing duplicated enforcement authority.
+
+During migration, the current in-process enforcement gate can act as a compatibility adapter and a conformance oracle. In the final distributed mode, policy decisions must not be independently made by both TypeScript and Go with different policy state.
+
+## Contracts Between the Planes
+
+The first version should use an OpenAPI-defined JSON/HTTP contract. FastAPI can publish the schema, while generated Go and TypeScript models prevent field drift. gRPC or streaming bundle delivery can be introduced later if profiling shows a need.
+
+### Execution intent
+
+An intent should contain at least:
+
+```json
+{
+  "request_id": "caller-idempotency-key",
+  "correlation_id": "trace-id",
+  "agent_claim": "agent:123",
+  "capability_request": {
+    "capability": "provider.generate",
+    "provider": "openai",
+    "model": "gpt-test",
+    "route": "/v1/chat/completions"
+  },
+  "input": {},
+  "context": {}
+}
+```
+
+`tenant_id`, trusted agent identity, provider identity, model identity, and route must be derived or checked against authenticated/canonical state. They must not be redefined by arbitrary `context` or `input` metadata.
+
+### Decision envelope
+
+A decision should contain at least:
+
+```json
+{
+  "decision_id": "generated-id",
+  "request_id": "caller-idempotency-key",
+  "correlation_id": "trace-id",
+  "decision": "ALLOW",
+  "allowed": true,
+  "reason_code": "POLICY_ALLOW",
+  "risk": {
+    "score": 10,
+    "level": "LOW",
+    "signals": []
+  },
+  "policy_version": "42",
+  "policy_digest": "sha256:...",
+  "evaluated_at": "2026-08-26T12:00:00Z"
+}
+```
+
+Stable reason codes are part of the API; prose is for people. A duplicated `allowed` boolean should either be omitted or mechanically derived from `decision`, because contradictory fields create unsafe client behavior.
+
+### Policy bundle
+
+A bundle should be immutable and include:
+
+- schema and evaluator versions;
+- tenant/workload scope;
+- monotonically increasing policy version;
+- issued-at and expiry timestamps;
+- canonical capability and route allowlists;
+- normalized rules and risk thresholds;
+- bundle digest, key identifier, and signature.
+
+The sidecar verifies scope, signature, version compatibility, expiry, and digest before atomically activating a bundle. Python and Go must share a corpus of golden inputs and expected decisions so that the compiler and evaluator cannot drift unnoticed.
+
+## Request and State Flows
+
+### Normal request
+
+1. The SDK sends an intent to its local sidecar.
+2. The sidecar authenticates the workload and resolves canonical identity.
+3. It validates the intent and resolves the canonical capability and route.
+4. It evaluates the current bundle.
+5. It creates and buffers an audit decision.
+6. On `ALLOW`, it invokes the configured upstream through the controlled path.
+7. On `BLOCK`, it returns a denial without calling upstream.
+8. On `ESCALATE`, it creates/reports a review request and returns without calling upstream.
+
+### Policy publication
+
+1. An authorized operator creates or updates a policy in FastAPI.
+2. The control plane validates and compiles it in a database transaction.
+3. It stores an immutable version, signs it, and marks it published.
+4. The sidecar fetches the update using mTLS and an `ETag`/current-version cursor.
+5. The sidecar validates the bundle and swaps it atomically; in-flight requests continue using the version with which they started.
+
+### Human review
+
+1. The sidecar returns `ESCALATE` and records the intent digest.
+2. FastAPI persists a pending review scoped to the tenant and authorized reviewers.
+3. Approval produces a short-lived, single-use token bound to the original request and policy version.
+4. The request is resubmitted through the sidecar. The sidecar validates the token and rechecks non-overridable safety rules before execution.
+
+Approval is not a direct call to the upstream and never means “skip the sidecar.”
+
+## Failure and Security Semantics
+
+The distributed boundary must have explicit behavior:
+
+| Condition | Required behavior |
+| --- | --- |
+| No valid policy has ever been loaded | Not ready; block governed execution |
+| Control plane unavailable, valid unexpired bundle present | Continue with the last-known-good bundle and emit degraded telemetry |
+| Bundle expired or signature/version invalid | Fail closed; never reuse it silently |
+| Unknown identity, capability, action, or route | `BLOCK` and audit |
+| Policy requires unavailable remote analysis | `BLOCK` or `ESCALATE` according to an explicit rule; never implicit `ALLOW` |
+| Audit delivery unavailable | Buffer locally within configured bounds; use fail-closed durability for designated high-impact capabilities |
+| Duplicate request ID | Return the same compatible decision or reject a conflicting payload digest |
+| Sidecar unavailable | SDK returns an enforcement-unavailable error; no direct-execution fallback |
+| Control-plane rollback attempt | Reject versions older than the active version unless a separately authorized rollback protocol is used |
+
+All network communication between sidecar and control plane should use mTLS. Operator endpoints need tenant-aware RBAC. Secrets and raw sensitive tool input should not be logged; audit schemas should support redaction and cryptographic integrity. Upstream destinations must come from signed policy/configuration to avoid turning the sidecar into an SSRF or open-proxy surface.
+
+## Suggested Repository Layout
+
+```text
+contracts/
+  openapi/
+  conformance/
+services/
+  control-plane/       # FastAPI application, migrations, policy compiler
+  sidecar/             # Go daemon, evaluator, proxy, policy cache
+core/packages/
+  sdk/                 # TypeScript client integration
+  runtime/             # agent lifecycle and compatibility adapter
+deploy/
+  docker-compose.yml   # local control plane, PostgreSQL, sidecar, test upstream
+```
+
+The current `core/main.py` and `core/interceptor.py` can seed the control-plane contract, but they should not remain a second production data plane after the Go sidecar is introduced.
+
+## Phased Delivery
+
+### Phase 1: Contract and vertical slice
+
+- Freeze `v1alpha1` intent, decision, error, bundle, audit, and review schemas.
+- Scaffold FastAPI and Go services in the proposed directories.
+- Add PostgreSQL migrations for tenants, identities, policy versions, and audit events.
+- Implement signed bundle publication and sidecar polling.
+- Implement local Go evaluation for `ALLOW` and `BLOCK` with a test upstream.
+- Add TypeScript sidecar client integration behind an explicit configuration flag.
+
+### Phase 2: Hard enforcement and escalation
+
+- Add proxy mode and strict upstream allowlisting.
+- Add `ESCALATE`, review persistence, and replay-safe approval tokens.
+- Add local durable audit buffering and idempotent batch ingestion.
+- Remove direct-execution fallback from distributed mode.
+
+### Phase 3: Hardening and operations
+
+- Add mTLS identity, operator RBAC, key rotation, revocation, rollback procedure, rate limits, payload limits, and redaction.
+- Add conformance, adversarial, outage, replay, stale-policy, and no-side-effect tests.
+- Publish latency/throughput benchmarks and service-level objectives.
+- Reconcile or retire duplicated TypeScript/Python evaluators.
+
+## Acceptance Criteria for the Architecture Epic
+
+- The boundary and ownership rules above are captured in an accepted ADR.
+- One versioned contract generates or validates Python, Go, and TypeScript models.
+- FastAPI publishes a signed policy bundle backed by PostgreSQL.
+- A Go sidecar validates and atomically activates that bundle.
+- An end-to-end test proves `ALLOW` reaches a test upstream and `BLOCK` and `ESCALATE` do not.
+- Unknown identities/capabilities and unavailable/expired policy fail closed.
+- Every outcome carries request, correlation, decision, and policy identifiers and is persisted idempotently.
+- Python and Go pass the same decision-conformance fixtures.
+- The TypeScript SDK cannot silently bypass the sidecar in distributed mode.
+- Failure-mode and benchmark results are documented.
+
+## Non-goals for the First Vertical Slice
+
+- A general-purpose service mesh or transparent interception of every network protocol.
+- A full policy-language invention.
+- Multi-region active/active control-plane deployment.
+- A production administration UI.
+- Arbitrary plugin execution inside the sidecar.
+
+## Proposed GitHub Issue
+
+### Title
+
+`RFC/EPIC: Introduce a Go enforcement sidecar and FastAPI governance control plane`
+
+### Description
+
+## Summary
+
+Introduce a local Go enforcement sidecar as the Aegisora data plane and turn the Python/FastAPI service into the governance control plane.
+
+The Go sidecar will intercept governed agent actions close to the workload, evaluate a signed and versioned policy bundle, and prevent unauthorized side effects. FastAPI will own tenant and identity management, policy lifecycle, bundle publication, human review, and audit ingestion. The existing TypeScript runtime and SDK will remain the developer integration and agent-lifecycle layer, but distributed mode must delegate governed execution to the sidecar without an ungoverned fallback.
+
+## Background
+
+Aegisora sits between an AI agent and anything on which that agent can cause a side effect: a tool, model provider, API, database, shell, or another agent.
+
+The agent supplies an untrusted execution intent. Aegisora must resolve the authentic identity and canonical capability, evaluate permission, policy, security, and risk, and produce exactly one of these decisions:
+
+- `ALLOW`: the governed action may proceed through the controlled path.
+- `BLOCK`: execution stops and no downstream side effect occurs.
+- `ESCALATE`: execution stops until an authorized review workflow approves it.
+
+The core invariant is:
+
+> No governed capability may cross the execution boundary before the canonical enforcement path has produced an explicit decision.
+
+Returning a decision that the caller is free to ignore is not sufficient. The sidecar must either proxy the allowed operation itself or issue a short-lived, request-bound authorization token that is enforced by the upstream gateway. Proxy mode is the preferred hard boundary.
+
+## Current State
+
+The repository currently has:
+
+- a TypeScript pnpm workspace containing the SDK, agent runtime, canonical agent and tool registries, enforcement gate, permission/policy/security/risk logic, provider gateway, plugins, audit, observability, and storage packages;
+- an in-process TypeScript execution path that attempts to enforce policy before tool and provider calls;
+- a canonical TypeScript `ToolRegistry` execution authority with scoped single-use authorization receipts and governance-boundary regression traces;
+- a small Python interceptor with an in-memory tenant policy store;
+- a FastAPI adapter exposing `GET /health` and `POST /intercept`;
+- an initial Go decision sidecar with signed local bundle activation, but no controlled upstream proxy, remote policy distribution, durable policy control plane, authenticated workload identity, or persistent human-review workflow.
+
+The Python prototype currently supports only `ALLOW` and `BLOCK`, trusts a caller-provided `tenant_id`, stores policy in memory, and does not enforce the downstream call. It is useful as a contract prototype but must not remain a second production data plane after the Go sidecar is introduced.
+
+The staged TypeScript governance model, canonical runtime execution authority, Python prototype, and Go policy evaluator operate at different layers. Their shared contract and security semantics must stay aligned so that moving enforcement to the sidecar does not introduce a second logical authority with different identity, capability, decision, or correlation state.
+
+## Proposed Architecture
+
+```text
+Agent / TypeScript SDK
+          |
+          | local execution intent
+          v
++-----------------------------------+
+| Go sidecar — data plane           |
+|                                   |
+| authenticate workload             |
+| resolve identity and capability   |
+| validate request                  |
+| evaluate active policy bundle     |
+| ALLOW / BLOCK / ESCALATE          |
+| buffer audit evidence             |
++-----------------+-----------------+
+                  |
+        ALLOW     |       BLOCK / ESCALATE
+                  |               |
+                  v               v
+       controlled upstream    no side effect
+       tool/provider/API      review if required
+
+FastAPI control plane
+          |
+          +--> PostgreSQL authoritative state
+          +--> tenant and workload identity management
+          +--> policy validation, compilation, versioning, signing
+          +--> sidecar registration and policy-bundle delivery
+          +--> human-review workflow
+          +--> audit ingestion and queries
+```
+
+The ownership model is:
+
+- FastAPI is authoritative for desired identity and policy state.
+- PostgreSQL is the durable system of record.
+- The Go sidecar is authoritative for enforcing the last valid policy snapshot for its workload.
+- The SDK, website, request body, and arbitrary metadata are not security authorities.
+- Redis may be used for disposable caching or queues, but not as the only policy authority.
+
+The control plane should not be on the normal per-request hot path. The sidecar evaluates deterministic compiled rules locally. A policy rule that requires a remote check must declare that dependency explicitly and must `BLOCK` or `ESCALATE`, never implicitly allow, when the check is unavailable.
+
+## Go Sidecar Responsibilities
+
+The sidecar is the local policy-enforcement point. It must:
+
+1. Listen on a Unix domain socket by default, with loopback TCP as an explicit alternative.
+2. Authenticate the calling workload and derive tenant and agent identity from workload credentials or pinned sidecar configuration.
+3. Treat payload identity fields as claims to verify, never as proof of identity.
+4. Enforce request-size, content-type, schema, deadline, and concurrency limits.
+5. Resolve canonical capability, action, provider/model identity, and upstream route without allowing arbitrary metadata to override them.
+6. Fetch, validate, and atomically activate signed, immutable policy bundles.
+7. Evaluate permission, policy, security, and risk locally with deny-overrides precedence.
+8. Produce exactly one of `ALLOW`, `BLOCK`, or `ESCALATE` with stable reason codes and policy-version evidence.
+9. Prevent downstream execution for `BLOCK` and `ESCALATE`.
+10. On `ALLOW`, proxy to a policy-allowlisted upstream or issue a short-lived, request-bound authorization token to an enforcement-aware gateway.
+11. Reject arbitrary upstream URLs so that it cannot become an SSRF or open proxy surface.
+12. Append a correlated decision to a bounded local write-ahead buffer and send audit events to FastAPI in idempotent batches.
+13. Expose liveness, readiness, metrics, build version, and active policy version.
+14. Never expose policy-administration endpoints or silently downgrade policy.
+
+## FastAPI Control-Plane Responsibilities
+
+The control plane must:
+
+1. Authenticate operators and sidecars separately.
+2. Apply tenant-scoped RBAC to all management and review operations.
+3. Manage tenants, workload/agent identities, capabilities, policy documents, routes, and sidecar registrations.
+4. Validate policy documents and compile them into a normalized representation understood by the Go evaluator.
+5. Store immutable policy versions in PostgreSQL.
+6. Hash, sign, publish, revoke, and intentionally roll back policy bundles.
+7. Deliver current bundles through authenticated polling with `ETag` or version cursors initially. Streaming delivery can be added later without changing policy semantics.
+8. Accept idempotent audit-event batches and provide tenant-scoped evidence queries.
+9. Persist `ESCALATE` review requests and authorize reviewer decisions.
+10. On approval, issue a short-lived, single-use token bound to the original intent digest, identity, capability, policy version, and expiry.
+11. Provide a reference evaluator for conformance tests without placing FastAPI in the ordinary action hot path.
+12. Support signing-key rotation, revocation, redaction rules, and audit integrity.
+
+## TypeScript Runtime and SDK Responsibilities
+
+The TypeScript packages must:
+
+- preserve the existing developer-facing SDK where practical;
+- convert tool and provider operations into the shared execution-intent contract;
+- send governed operations to the local sidecar;
+- propagate request and correlation identifiers;
+- surface `BLOCK`, `ESCALATE`, and enforcement-unavailable results clearly;
+- never fall back to an ungoverned direct tool/provider call when the sidecar is unavailable;
+- avoid independently evaluating a different policy version in distributed mode;
+- retain agent lifecycle, planning, provider adapters, and compatibility logic that do not conflict with the sidecar’s enforcement authority.
+
+The existing in-process enforcement gate may temporarily act as a compatibility adapter and conformance oracle during migration. It must not remain a competing production policy authority.
+
+## Versioned Contracts
+
+Define one OpenAPI `v1alpha1` contract and generate or validate models for Python, Go, and TypeScript. Begin with JSON/HTTP. gRPC or streaming may be added later only if profiling demonstrates the need.
+
+### Execution intent
+
+```json
+{
+  "request_id": "caller-idempotency-key",
+  "correlation_id": "trace-id",
+  "agent_claim": "agent:123",
+  "capability_request": {
+    "capability": "provider.generate",
+    "provider": "openai",
+    "model": "gpt-test",
+    "route": "/v1/chat/completions"
+  },
+  "input": {},
+  "context": {}
+}
+```
+
+Tenant, trusted agent identity, canonical provider/model identity, and upstream route must be derived from or checked against authenticated state. An `input` or `context` field may not redefine them.
+
+### Decision envelope
+
+```json
+{
+  "decision_id": "generated-id",
+  "request_id": "caller-idempotency-key",
+  "correlation_id": "trace-id",
+  "decision": "ALLOW",
+  "allowed": true,
+  "reason_code": "POLICY_ALLOW",
+  "risk": {
+    "score": 10,
+    "level": "LOW",
+    "signals": []
+  },
+  "policy_version": "42",
+  "policy_digest": "sha256:...",
+  "evaluated_at": "2026-08-26T12:00:00Z"
+}
+```
+
+Reason codes are stable API values; messages are explanatory. Do not maintain an independently writable `allowed` boolean because it can contradict `decision`. If compatibility requires it, derive it mechanically as `decision == ALLOW`.
+
+### Policy bundle
+
+Each bundle must be immutable and contain:
+
+- schema and evaluator versions;
+- tenant/workload scope;
+- monotonically increasing policy version;
+- issue and expiry timestamps;
+- canonical capability and route allowlists;
+- normalized rules and risk thresholds;
+- digest, signing-key identifier, and signature.
+
+The sidecar verifies scope, signature, supported versions, digest, expiry, and rollback status before atomically activating a bundle. In-flight requests keep the policy version with which they began.
+
+Python and Go must share golden execution intents and expected decisions. CI must fail if the control-plane reference evaluator and Go evaluator disagree.
+
+## Required API Surfaces
+
+Exact paths may be adjusted while freezing OpenAPI, but the first contract must cover:
+
+### Sidecar-local API
+
+- health, readiness, and version endpoints;
+- submit an execution intent and receive its decision;
+- preferred proxy/execute operation for allowlisted upstreams;
+- approval-token resubmission for reviewed intents.
+
+### Control-plane sidecar API
+
+- register/authenticate a sidecar;
+- fetch the current policy bundle conditionally by version or `ETag`;
+- ingest idempotent audit batches;
+- create or update escalation-review state;
+- expose signing-key and revocation information securely.
+
+### Control-plane operator API
+
+- tenant, identity, capability, route, and policy management;
+- policy validation, publication, revocation, and authorized rollback;
+- pending-review queries and approve/deny actions;
+- audit/evidence queries scoped by tenant and operator role.
+
+## Runtime Flows
+
+### Normal request
+
+1. The SDK sends an intent to its local sidecar.
+2. The sidecar authenticates the workload and resolves canonical identity.
+3. It validates the intent and resolves the canonical capability and route.
+4. It evaluates the active bundle.
+5. It creates and buffers a correlated audit decision.
+6. On `ALLOW`, it invokes the upstream through the controlled path.
+7. On `BLOCK`, it returns a denial without calling upstream.
+8. On `ESCALATE`, it creates or reports a review request and returns without calling upstream.
+
+### Policy publication
+
+1. An authorized operator submits a policy change to FastAPI.
+2. The control plane validates and compiles it in a database transaction.
+3. It stores an immutable version, signs it, and marks it published.
+4. An authenticated sidecar fetches the update using a version cursor or conditional request.
+5. The sidecar validates and atomically activates the bundle.
+6. Audit and readiness telemetry report the active version.
+
+### Human review
+
+1. The sidecar returns `ESCALATE` and records the intent digest.
+2. FastAPI persists a pending review scoped to the tenant and eligible reviewers.
+3. A reviewer approves or denies it through an authenticated operator API.
+4. Approval creates a short-lived, single-use token bound to the original request, identity, capability, intent digest, and policy version.
+5. The request is resubmitted through the sidecar.
+6. The sidecar validates the token and rechecks non-overridable safety rules before allowing execution.
+
+Approval never directly calls the upstream and never bypasses the sidecar.
+
+## Failure Semantics
+
+| Condition | Required behavior |
+| --- | --- |
+| No valid policy has ever been loaded | Sidecar is not ready and blocks governed execution |
+| Control plane unavailable with an unexpired bundle | Continue using the last-known-good bundle and emit degraded telemetry |
+| Bundle expired, malformed, incompatible, or unsigned | Fail closed |
+| Unknown identity, capability, action, provider, or route | `BLOCK` and audit |
+| Required remote analysis unavailable | Explicitly `BLOCK` or `ESCALATE`; never implicit `ALLOW` |
+| Audit delivery temporarily unavailable | Buffer locally within configured bounds |
+| Required audit durability unavailable for a high-impact capability | Fail closed according to policy |
+| Duplicate request ID with the same payload digest | Return the compatible idempotent result |
+| Duplicate request ID with a different payload digest | Reject and audit the conflict |
+| Sidecar unavailable | SDK returns enforcement unavailable; no direct fallback |
+| Older policy received unexpectedly | Reject unless an authenticated rollback protocol authorizes it |
+
+Timeout and cancellation behavior must guarantee that an ambiguous client response cannot cause an untracked retry or duplicate side effect. Proxy operations need idempotency semantics appropriate to their upstream.
+
+## Security Requirements
+
+- Use mTLS between sidecars and the control plane.
+- Protect the Unix socket with filesystem permissions; secure loopback mode separately.
+- Authenticate operators independently from workloads and apply tenant-aware RBAC.
+- Never use a caller-provided `tenant_id` or `agent_id` as identity proof.
+- Strip or reject metadata that conflicts with canonical identity, capability, provider, model, policy, or route fields.
+- Source upstream destinations from signed policy/configuration.
+- Redact secrets and sensitive tool input from logs and audit events.
+- Sign policy bundles and support signing-key rotation and revocation.
+- Protect approval tokens from replay and bind them to one intent and expiry.
+- Apply payload, concurrency, rate, decompression, and deadline limits.
+- Preserve correlation and policy-version evidence for all three decisions.
+- Add adversarial tests proving `BLOCK` and `ESCALATE` never reach upstream.
+
+## Suggested Repository Layout
+
+```text
+contracts/
+  openapi/
+  conformance/
+services/
+  control-plane/       # FastAPI, migrations, policy compiler and management API
+  sidecar/             # Go daemon, evaluator, proxy and policy cache
+core/packages/
+  sdk/                 # TypeScript sidecar client integration
+  runtime/             # agent lifecycle and migration adapter
+deploy/
+  docker-compose.yml   # PostgreSQL, control plane, sidecar and test upstream
+```
+
+## Delivery Plan
+
+### Phase 1: Contract and vertical slice
+
+- Freeze OpenAPI schemas for intent, decision, errors, policy bundle, audit batch, and review records.
+- Add cross-language conformance fixtures.
+- Scaffold the FastAPI control plane and Go sidecar.
+- Add PostgreSQL migrations for tenants, identities, policy versions, sidecar registrations, and audit events.
+- Implement policy validation, immutable versions, signing, publication, and sidecar polling.
+- Implement atomic bundle activation and local Go `ALLOW`/`BLOCK` evaluation.
+- Add a controlled test upstream.
+- Add a TypeScript sidecar client behind explicit distributed-mode configuration.
+- Prove that an allowed test request reaches upstream and a blocked request does not.
+
+### Phase 2: Hard enforcement and escalation
+
+- Add sidecar proxy mode with strict route allowlisting.
+- Implement `ESCALATE` and persistent human review.
+- Implement request-bound, expiring, single-use approval tokens.
+- Add local durable audit buffering and idempotent batch ingestion.
+- Define proxy retry and idempotency behavior.
+- Remove any direct-execution fallback from distributed mode.
+
+### Phase 3: Security and operational hardening
+
+- Add sidecar/control-plane mTLS and operator RBAC.
+- Add signing-key rotation, revocation, and authorized rollback procedures.
+- Add rate, payload, deadline, and concurrency controls.
+- Add redaction and audit-integrity controls.
+- Add stale-policy, outage, replay, conflicting-idempotency-key, and no-side-effect adversarial tests.
+- Add metrics, traces, dashboards, and operational runbooks.
+- Publish latency and throughput benchmarks plus initial service-level objectives.
+- Reconcile or retire duplicated TypeScript and Python evaluators.
+
+## Acceptance Criteria
+
+- [ ] The data-plane/control-plane ownership model is explicit in code and deployment configuration.
+- [ ] One versioned OpenAPI contract generates or validates Python, Go, and TypeScript models.
+- [ ] PostgreSQL stores tenants, authenticated workload identities, immutable policy versions, reviews, and audit evidence.
+- [ ] FastAPI validates, signs, publishes, revokes, and serves policy bundles.
+- [ ] The Go sidecar verifies and atomically activates a scoped policy bundle.
+- [ ] The sidecar returns `ALLOW`, `BLOCK`, and `ESCALATE` with stable reason, correlation, and policy identifiers.
+- [ ] An end-to-end test proves only `ALLOW` reaches a test upstream.
+- [ ] Unknown identities, capabilities, actions, and routes fail closed.
+- [ ] Missing, expired, invalid, incompatible, or unexpectedly rolled-back policy fails closed.
+- [ ] Control-plane outage behavior with a last-known-good bundle is tested.
+- [ ] Audit delivery is idempotent and tolerates a temporary control-plane outage without losing buffered decisions within configured limits.
+- [ ] Approved escalations use replay-resistant tokens and pass back through the sidecar.
+- [ ] Python and Go pass the same golden decision fixtures.
+- [ ] The TypeScript SDK cannot silently bypass the sidecar in distributed mode.
+- [ ] mTLS, operator RBAC, signing-key lifecycle, redaction, and upstream allowlisting are covered by tests or documented operational validation.
+- [ ] Benchmark results and failure-mode behavior are documented.
+
+## Non-goals for the Initial Vertical Slice
+
+- Building a general-purpose service mesh.
+- Transparently intercepting every network protocol.
+- Inventing a full general-purpose policy language.
+- Multi-region active/active control-plane deployment.
+- Building a production administration UI.
+- Running arbitrary plugins inside the sidecar.

--- a/services/sidecar/.dockerignore
+++ b/services/sidecar/.dockerignore
@@ -1,0 +1,4 @@
+bin/
+coverage/
+*.out
+.git/

--- a/services/sidecar/.gitignore
+++ b/services/sidecar/.gitignore
@@ -1,0 +1,3 @@
+bin/
+coverage/
+*.out

--- a/services/sidecar/Dockerfile
+++ b/services/sidecar/Dockerfile
@@ -1,0 +1,30 @@
+# syntax=docker/dockerfile:1
+
+ARG GO_VERSION=1.27
+FROM golang:${GO_VERSION}-alpine AS build
+
+WORKDIR /src
+
+COPY go.mod ./
+RUN go mod download
+
+COPY . .
+
+ARG VERSION=dev
+ARG COMMIT=unknown
+
+RUN CGO_ENABLED=0 go build \
+    -trimpath \
+    -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${COMMIT}" \
+    -o /out/aegisora-sidecar \
+    ./cmd/aegisora-sidecar
+
+FROM gcr.io/distroless/static-debian12:nonroot
+
+COPY --from=build /out/aegisora-sidecar /aegisora-sidecar
+
+ENV AEGISORA_SIDECAR_HTTP_ADDRESS=0.0.0.0:8081
+
+EXPOSE 8081
+
+ENTRYPOINT ["/aegisora-sidecar"]

--- a/services/sidecar/Makefile
+++ b/services/sidecar/Makefile
@@ -1,0 +1,55 @@
+APP := aegisora-sidecar
+BIN_DIR := bin
+GO ?= go
+VERSION ?= dev
+COMMIT ?= unknown
+LDFLAGS := -s -w -X main.version=$(VERSION) -X main.commit=$(COMMIT)
+
+.DEFAULT_GOAL := help
+
+.PHONY: help deps tidy fmt fmt-check vet test test-race build tools run verify clean docker-build
+
+help: ## Show available commands.
+	@awk 'BEGIN {FS = ":.*## "}; /^[a-zA-Z0-9_-]+:.*## / {printf "%-16s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+deps: ## Download module dependencies.
+	$(GO) mod download
+
+tidy: ## Normalize go.mod and go.sum.
+	$(GO) mod tidy
+
+fmt: ## Format Go source files.
+	$(GO) fmt ./...
+
+fmt-check: ## Fail if Go source files are not formatted.
+	@test -z "$$(gofmt -l .)" || { gofmt -l .; exit 1; }
+
+vet: ## Run the Go static analyzer.
+	$(GO) vet ./...
+
+test: ## Run unit tests.
+	$(GO) test ./...
+
+test-race: ## Run unit tests with the race detector.
+	$(GO) test -race ./...
+
+build: ## Build the sidecar binary.
+	mkdir -p $(BIN_DIR)
+	$(GO) build -trimpath -ldflags "$(LDFLAGS)" -o $(BIN_DIR)/$(APP) ./cmd/aegisora-sidecar
+
+tools: ## Build local policy key-generation and signing tools.
+	mkdir -p $(BIN_DIR)
+	$(GO) build -trimpath -o $(BIN_DIR)/aegisora-policy-keygen ./cmd/aegisora-policy-keygen
+	$(GO) build -trimpath -o $(BIN_DIR)/aegisora-policy-sign ./cmd/aegisora-policy-sign
+
+run: ## Run the sidecar locally.
+	$(GO) run ./cmd/aegisora-sidecar
+
+verify: fmt-check vet test build ## Run the local verification suite.
+
+clean: ## Remove generated sidecar and policy-tool binaries.
+	$(RM) $(BIN_DIR)/$(APP) $(BIN_DIR)/aegisora-policy-keygen $(BIN_DIR)/aegisora-policy-sign
+	@rmdir $(BIN_DIR) 2>/dev/null || true
+
+docker-build: ## Build the sidecar container image.
+	docker build --build-arg VERSION=$(VERSION) --build-arg COMMIT=$(COMMIT) -t aegisora/$(APP):$(VERSION) .

--- a/services/sidecar/README.md
+++ b/services/sidecar/README.md
@@ -1,0 +1,164 @@
+# Aegisora Go Sidecar
+
+Go 1.27 implementation of the Aegisora `v1alpha1` local enforcement data plane.
+
+The current vertical slice accepts an execution intent, validates it, evaluates an active signed policy bundle, records a correlated audit event, and returns exactly one canonical decision: `ALLOW`, `BLOCK`, or `ESCALATE`.
+
+It is fail closed:
+
+- no valid unexpired policy means `BLOCK` and readiness `503`;
+- a caller cannot activate an unsigned, modified, or expired bundle;
+- policy scope mismatch means `BLOCK`;
+- duplicate request IDs return the original decision only when the intent is identical and the same policy version and digest remain active;
+- an audit write failure prevents a successful decision response;
+- `allowed` is always derived from `decision == ALLOW`.
+
+This slice is an authorization and policy-evaluation service. It does not yet proxy an approved upstream call, persist audit events to disk, poll a FastAPI control plane, or authenticate the local workload transport. Those hard-boundary features are intentionally separate follow-up PRs.
+
+## Request path
+
+```text
+POST /v1alpha1/execution/intent
+        |
+        +--> strict JSON, size, and contract validation
+        +--> request-ID replay/conflict check
+        +--> valid, unexpired, Ed25519-verified active bundle
+        +--> tenant-scoped agent/capability policy evaluation
+        +--> deny-overrides decision resolution
+        +--> bounded correlated audit event
+        |
+        +--> ALLOW | BLOCK | ESCALATE
+```
+
+The sidecar implements the models in:
+
+- `contracts/openapi/v1alpha1/openapi.yaml`
+- `contracts/conformance/v1alpha1/semantic-fixtures.json`
+
+Go tests load the shared semantic fixtures directly, so contract drift fails the sidecar build.
+
+## Build and test
+
+Run from this directory:
+
+```bash
+make fmt-check
+make vet
+make test
+make test-race
+make verify
+make build VERSION=0.1.0 COMMIT="$(git rev-parse --short HEAD)"
+make tools
+```
+
+The service and local policy tools are written to `bin/`, which is ignored by Git.
+
+## Create and sign a local policy
+
+Production signing belongs in the FastAPI control plane or a dedicated signing service. The local tools exist only for development and conformance testing.
+
+Generate an Ed25519 key pair:
+
+```bash
+make tools
+./bin/aegisora-policy-keygen > /tmp/aegisora-policy-keypair.json
+```
+
+The file contains base64-encoded `public_key` and `private_key` values. Keep the private key out of the repository. Export the private key, then sign the example bundle:
+
+```bash
+export AEGISORA_POLICY_PRIVATE_KEY="<private_key>"
+./bin/aegisora-policy-sign \
+  -bundle ./examples/policy-bundle.unsigned.json \
+  > /tmp/aegisora-policy.signed.json
+```
+
+The digest covers the bundle ID, scope, version, expiry, and normalized policy document. The Ed25519 signature covers that digest. Editing any protected field after signing makes activation fail.
+
+## Run with the signed policy
+
+```bash
+export AEGISORA_SIDECAR_POLICY_BUNDLE=/tmp/aegisora-policy.signed.json
+export AEGISORA_SIDECAR_POLICY_PUBLIC_KEY="<public_key>"
+make run
+```
+
+Submit the example intent from another terminal:
+
+```bash
+curl --fail-with-body \
+  -H 'Content-Type: application/json' \
+  --data-binary @./examples/intent-openai.json \
+  http://127.0.0.1:8081/v1alpha1/execution/intent
+```
+
+The OpenAI rule returns an `ALLOW` envelope. Changing the provider to `anthropic` returns `ESCALATE`; any unmatched provider returns the default `BLOCK`.
+
+## HTTP endpoints
+
+| Endpoint | Behavior |
+| --- | --- |
+| `GET /healthz` | Operational liveness plus build metadata |
+| `GET /readyz` | Compatibility readiness endpoint |
+| `GET /v1alpha1/health` | Contract health response |
+| `GET /v1alpha1/readiness` | `ready` only while an active bundle is valid and unexpired |
+| `GET /v1alpha1/policies/active` | Active policy version, digest, and expiry |
+| `POST /v1alpha1/execution/intent` | Strictly validate and evaluate an execution intent |
+
+Malformed transport input returns an HTTP error. A valid execution intent always receives a decision envelope, including fail-closed policy outcomes.
+
+## Configuration
+
+| Environment variable | Default | Meaning |
+| --- | --- | --- |
+| `AEGISORA_SIDECAR_HTTP_ADDRESS` | `127.0.0.1:8081` | HTTP listener |
+| `AEGISORA_SIDECAR_READ_HEADER_TIMEOUT` | `5s` | Header-read timeout |
+| `AEGISORA_SIDECAR_READ_TIMEOUT` | `15s` | Total request-read timeout, including the body |
+| `AEGISORA_SIDECAR_SHUTDOWN_TIMEOUT` | `10s` | Graceful-shutdown deadline |
+| `AEGISORA_SIDECAR_MAX_BODY_BYTES` | `1048576` | Maximum execution-intent body size |
+| `AEGISORA_SIDECAR_AUDIT_CAPACITY` | `10000` | In-memory bounded audit-event capacity |
+| `AEGISORA_SIDECAR_DECISION_CACHE_SIZE` | `10000` | In-memory idempotency decision capacity |
+| `AEGISORA_SIDECAR_POLICY_BUNDLE` | unset | Signed policy bundle JSON path |
+| `AEGISORA_SIDECAR_POLICY_PUBLIC_KEY` | unset | Base64 Ed25519 verification key |
+
+The policy path and public key must be configured together. Starting without both is allowed for liveness diagnostics, but the process remains not ready and governed requests fail closed.
+
+## Policy dialect implemented by this slice
+
+The OpenAPI contract intentionally leaves `PolicyBundle.policy` extensible. This sidecar currently compiles a deliberately small deterministic dialect:
+
+```json
+{
+  "default_decision": "BLOCK",
+  "rules": [
+    {
+      "agent_claim": "agent:demo",
+      "capability": "provider.generate",
+      "provider": "openai",
+      "model": "gpt-test",
+      "route": "/v1/chat/completions",
+      "decision": "ALLOW",
+      "reason_code": "OPENAI_ALLOWED",
+      "risk": {
+        "score": 10,
+        "level": "LOW",
+        "signals": []
+      }
+    }
+  ]
+}
+```
+
+Every match field is optional and acts as a wildcard when omitted. All matching rules are considered; precedence is `BLOCK > ESCALATE > ALLOW`. This deny-overrides rule prevents an earlier broad allow rule from defeating a narrower block rule.
+
+## PR boundaries
+
+Recommended follow-up slices:
+
+1. Controlled upstream proxy and strict route allowlisting, proving zero upstream calls for `BLOCK` and `ESCALATE`.
+2. Unix-domain-socket workload authentication and canonical identity derivation.
+3. FastAPI bundle polling, public-key rotation, monotonic rollback protection, and last-known-good storage.
+4. Durable audit WAL, idempotent batch delivery, and review-request creation.
+5. TypeScript SDK distributed-mode client with no direct-execution fallback.
+
+See [Repository Investigation](../../REPOSITORY_INVESTIGATION.md) and [Go Sidecar and FastAPI Control Plane](../../docs/architecture/go-sidecar-fastapi-control-plane.md) for the broader architecture and planned delivery slices.

--- a/services/sidecar/cmd/aegisora-policy-keygen/main.go
+++ b/services/sidecar/cmd/aegisora-policy-keygen/main.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/aegisora-ai/aegisora/services/sidecar/internal/policy"
+)
+
+func main() {
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "aegisora-policy-keygen:", err)
+		os.Exit(1)
+	}
+	output := struct {
+		Algorithm  string `json:"algorithm"`
+		PublicKey  string `json:"public_key"`
+		PrivateKey string `json:"private_key"`
+	}{
+		Algorithm:  "Ed25519",
+		PublicKey:  policy.EncodePublicKey(publicKey),
+		PrivateKey: base64.StdEncoding.EncodeToString(privateKey),
+	}
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(output); err != nil {
+		fmt.Fprintln(os.Stderr, "aegisora-policy-keygen:", err)
+		os.Exit(1)
+	}
+}

--- a/services/sidecar/cmd/aegisora-policy-sign/main.go
+++ b/services/sidecar/cmd/aegisora-policy-sign/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/aegisora-ai/aegisora/services/sidecar/internal/policy"
+)
+
+func main() {
+	bundlePath := flag.String("bundle", "", "path to an unsigned policy bundle JSON file")
+	flag.Parse()
+	if strings.TrimSpace(*bundlePath) == "" {
+		exit(errors.New("-bundle is required"))
+	}
+
+	privateKey, err := privateKeyFromEnvironment()
+	if err != nil {
+		exit(err)
+	}
+	bundle, err := policy.LoadFile(*bundlePath)
+	if err != nil {
+		exit(err)
+	}
+	signed, err := policy.Sign(bundle, privateKey)
+	if err != nil {
+		exit(err)
+	}
+
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(signed); err != nil {
+		exit(fmt.Errorf("encode signed policy bundle: %w", err))
+	}
+}
+
+func privateKeyFromEnvironment() (ed25519.PrivateKey, error) {
+	encoded := strings.TrimSpace(os.Getenv("AEGISORA_POLICY_PRIVATE_KEY"))
+	if encoded == "" {
+		return nil, errors.New("AEGISORA_POLICY_PRIVATE_KEY is required")
+	}
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, fmt.Errorf("decode AEGISORA_POLICY_PRIVATE_KEY: %w", err)
+	}
+	if len(decoded) != ed25519.PrivateKeySize {
+		return nil, fmt.Errorf("AEGISORA_POLICY_PRIVATE_KEY must decode to %d bytes", ed25519.PrivateKeySize)
+	}
+	return ed25519.PrivateKey(decoded), nil
+}
+
+func exit(err error) {
+	fmt.Fprintln(os.Stderr, "aegisora-policy-sign:", err)
+	os.Exit(1)
+}

--- a/services/sidecar/cmd/aegisora-sidecar/main.go
+++ b/services/sidecar/cmd/aegisora-sidecar/main.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/aegisora-ai/aegisora/services/sidecar/internal/audit"
+	"github.com/aegisora-ai/aegisora/services/sidecar/internal/config"
+	"github.com/aegisora-ai/aegisora/services/sidecar/internal/domain"
+	"github.com/aegisora-ai/aegisora/services/sidecar/internal/engine"
+	"github.com/aegisora-ai/aegisora/services/sidecar/internal/httpapi"
+	"github.com/aegisora-ai/aegisora/services/sidecar/internal/policy"
+)
+
+var (
+	version = "dev"
+	commit  = "unknown"
+)
+
+func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+
+	cfg, err := config.Load()
+	if err != nil {
+		logger.Error("invalid sidecar configuration", "error", err)
+		os.Exit(1)
+	}
+
+	policyManager := policy.NewManager(nil)
+	if cfg.PolicyBundlePath != "" {
+		verifier, verifierErr := policy.NewEd25519Verifier(cfg.PolicyPublicKey)
+		if verifierErr != nil {
+			logger.Error("invalid policy verifier configuration", "error", verifierErr)
+			os.Exit(1)
+		}
+		policyManager = policy.NewManager(verifier)
+		bundle, loadErr := policy.LoadFile(cfg.PolicyBundlePath)
+		if loadErr != nil {
+			logger.Error("load policy bundle", "error", loadErr)
+			os.Exit(1)
+		}
+		if activateErr := policyManager.Activate(bundle, time.Now()); activateErr != nil {
+			logger.Error("activate policy bundle", "error", activateErr)
+			os.Exit(1)
+		}
+		logger.Info(
+			"activated policy bundle",
+			"bundle_id", bundle.BundleID,
+			"policy_version", bundle.Version,
+			"policy_digest", bundle.Digest,
+			"expires_at", bundle.ExpiresAt,
+		)
+	}
+
+	auditSink, err := audit.NewMemorySink(cfg.AuditCapacity)
+	if err != nil {
+		logger.Error("configure audit sink", "error", err)
+		os.Exit(1)
+	}
+	enforcementEngine, err := engine.New(engine.Options{
+		Policies:     policyManager,
+		Audit:        auditSink,
+		CacheEntries: cfg.DecisionCacheSize,
+	})
+	if err != nil {
+		logger.Error("configure enforcement engine", "error", err)
+		os.Exit(1)
+	}
+
+	handler := httpapi.New(httpapi.Options{
+		ServiceName:      "aegisora-sidecar",
+		Version:          version,
+		Commit:           commit,
+		Evaluator:        enforcementEngine,
+		MaximumBodyBytes: cfg.MaximumBodyBytes,
+		Ready: func() bool {
+			return policyManager.Ready(time.Now())
+		},
+		ActivePolicy: func() (domain.ActivePolicyVersion, bool) {
+			return policyManager.Metadata(time.Now())
+		},
+	})
+
+	server := &http.Server{
+		Addr:              cfg.HTTPAddress,
+		Handler:           handler,
+		ReadHeaderTimeout: cfg.ReadHeaderTimeout,
+		ReadTimeout:       cfg.ReadTimeout,
+	}
+
+	signalContext, stop := signal.NotifyContext(
+		context.Background(),
+		syscall.SIGINT,
+		syscall.SIGTERM,
+	)
+	defer stop()
+
+	serverErrors := make(chan error, 1)
+	go func() {
+		logger.Info(
+			"starting sidecar",
+			"address", cfg.HTTPAddress,
+			"version", version,
+			"commit", commit,
+		)
+
+		if listenErr := server.ListenAndServe(); listenErr != nil && !errors.Is(listenErr, http.ErrServerClosed) {
+			serverErrors <- listenErr
+		}
+	}()
+
+	var runErr error
+	select {
+	case <-signalContext.Done():
+		logger.Info("shutdown signal received")
+	case runErr = <-serverErrors:
+		logger.Error("sidecar server stopped", "error", runErr)
+	}
+
+	shutdownContext, cancel := context.WithTimeout(
+		context.Background(),
+		cfg.ShutdownTimeout,
+	)
+	defer cancel()
+
+	if err := server.Shutdown(shutdownContext); err != nil {
+		logger.Error("graceful shutdown failed", "error", err)
+		if runErr == nil {
+			runErr = err
+		}
+	}
+
+	if runErr != nil {
+		os.Exit(1)
+	}
+}

--- a/services/sidecar/examples/intent-openai.json
+++ b/services/sidecar/examples/intent-openai.json
@@ -1,0 +1,17 @@
+{
+  "request_id": "req-local-001",
+  "correlation_id": "corr-local-001",
+  "agent_claim": "agent:demo",
+  "capability_request": {
+    "capability": "provider.generate",
+    "provider": "openai",
+    "model": "gpt-test",
+    "route": "/v1/chat/completions"
+  },
+  "input": {
+    "prompt": "hello"
+  },
+  "context": {
+    "source": "local-example"
+  }
+}

--- a/services/sidecar/examples/policy-bundle.unsigned.json
+++ b/services/sidecar/examples/policy-bundle.unsigned.json
@@ -1,0 +1,37 @@
+{
+  "bundle_id": "bundle-local-demo",
+  "scope": {
+    "tenant": "tenant-local",
+    "agent": "agent:demo",
+    "capability": "provider.generate"
+  },
+  "version": "policy-local-1",
+  "digest": "unsigned",
+  "expires_at": "2099-01-01T00:00:00Z",
+  "signature": "unsigned",
+  "policy": {
+    "default_decision": "BLOCK",
+    "rules": [
+      {
+        "capability": "provider.generate",
+        "provider": "openai",
+        "decision": "ALLOW",
+        "reason_code": "OPENAI_ALLOWED",
+        "risk": {
+          "score": 10,
+          "level": "LOW"
+        }
+      },
+      {
+        "capability": "provider.generate",
+        "provider": "anthropic",
+        "decision": "ESCALATE",
+        "reason_code": "ANTHROPIC_REVIEW_REQUIRED",
+        "risk": {
+          "score": 50,
+          "level": "MEDIUM"
+        }
+      }
+    ]
+  }
+}

--- a/services/sidecar/go.mod
+++ b/services/sidecar/go.mod
@@ -1,0 +1,3 @@
+module github.com/aegisora-ai/aegisora/services/sidecar
+
+go 1.27.0

--- a/services/sidecar/internal/audit/sink.go
+++ b/services/sidecar/internal/audit/sink.go
@@ -1,0 +1,63 @@
+package audit
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+
+	"github.com/aegisora-ai/aegisora/services/sidecar/internal/domain"
+)
+
+type Sink interface {
+	Append(context.Context, domain.AuditEvent) error
+}
+
+type MemorySink struct {
+	mu       sync.RWMutex
+	capacity int
+	events   []domain.AuditEvent
+}
+
+func NewMemorySink(capacity int) (*MemorySink, error) {
+	if capacity <= 0 {
+		return nil, errors.New("audit capacity must be greater than zero")
+	}
+
+	return &MemorySink{capacity: capacity}, nil
+}
+
+func (sink *MemorySink) Append(_ context.Context, event domain.AuditEvent) error {
+	sink.mu.Lock()
+	defer sink.mu.Unlock()
+
+	if len(sink.events) == sink.capacity {
+		copy(sink.events, sink.events[1:])
+		sink.events = sink.events[:sink.capacity-1]
+	}
+	sink.events = append(sink.events, cloneEvent(event))
+
+	return nil
+}
+
+func (sink *MemorySink) Events() []domain.AuditEvent {
+	sink.mu.RLock()
+	defer sink.mu.RUnlock()
+
+	events := make([]domain.AuditEvent, len(sink.events))
+	for index, event := range sink.events {
+		events[index] = cloneEvent(event)
+	}
+	return events
+}
+
+func cloneEvent(event domain.AuditEvent) domain.AuditEvent {
+	cloned := event
+	if event.Payload != nil {
+		cloned.Payload = make(map[string]json.RawMessage, len(event.Payload))
+		for key, value := range event.Payload {
+			cloned.Payload[key] = append(json.RawMessage(nil), value...)
+		}
+	}
+	return cloned
+}

--- a/services/sidecar/internal/audit/sink_test.go
+++ b/services/sidecar/internal/audit/sink_test.go
@@ -1,0 +1,50 @@
+package audit
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/aegisora-ai/aegisora/services/sidecar/internal/domain"
+)
+
+func TestMemorySinkIsBounded(t *testing.T) {
+	sink, err := NewMemorySink(2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"one", "two", "three"} {
+		if err := sink.Append(context.Background(), domain.AuditEvent{EventID: id}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	events := sink.Events()
+	if len(events) != 2 || events[0].EventID != "two" || events[1].EventID != "three" {
+		t.Fatalf("Events() = %#v", events)
+	}
+}
+
+func TestMemorySinkIsolatesPayloads(t *testing.T) {
+	sink, err := NewMemorySink(2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	event := domain.AuditEvent{
+		EventID: "event-1",
+		Payload: map[string]json.RawMessage{
+			"decision": json.RawMessage(`"ALLOW"`),
+		},
+	}
+	if err := sink.Append(context.Background(), event); err != nil {
+		t.Fatal(err)
+	}
+
+	event.Payload["decision"][1] = 'X'
+	returned := sink.Events()
+	returned[0].Payload["decision"][1] = 'Y'
+
+	if got := string(sink.Events()[0].Payload["decision"]); got != `"ALLOW"` {
+		t.Fatalf("stored payload = %s, want isolated original", got)
+	}
+}

--- a/services/sidecar/internal/config/config.go
+++ b/services/sidecar/internal/config/config.go
@@ -1,0 +1,152 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	defaultHTTPAddress       = "127.0.0.1:8081"
+	defaultReadHeaderTimeout = 5 * time.Second
+	defaultReadTimeout       = 15 * time.Second
+	defaultShutdownTimeout   = 10 * time.Second
+	defaultMaximumBodyBytes  = int64(1 << 20)
+	defaultAuditCapacity     = 10_000
+	defaultDecisionCacheSize = 10_000
+)
+
+// Config contains process-level settings only. Policy and identity settings
+// will belong to their own components once those contracts are agreed.
+type Config struct {
+	HTTPAddress       string
+	ReadHeaderTimeout time.Duration
+	ReadTimeout       time.Duration
+	ShutdownTimeout   time.Duration
+	MaximumBodyBytes  int64
+	AuditCapacity     int
+	DecisionCacheSize int
+	PolicyBundlePath  string
+	PolicyPublicKey   string
+}
+
+// Load reads sidecar process settings from the environment.
+func Load() (Config, error) {
+	readHeaderTimeout, err := durationFromEnvironment(
+		"AEGISORA_SIDECAR_READ_HEADER_TIMEOUT",
+		defaultReadHeaderTimeout,
+	)
+	if err != nil {
+		return Config{}, err
+	}
+	readTimeout, err := durationFromEnvironment(
+		"AEGISORA_SIDECAR_READ_TIMEOUT",
+		defaultReadTimeout,
+	)
+	if err != nil {
+		return Config{}, err
+	}
+
+	shutdownTimeout, err := durationFromEnvironment(
+		"AEGISORA_SIDECAR_SHUTDOWN_TIMEOUT",
+		defaultShutdownTimeout,
+	)
+	if err != nil {
+		return Config{}, err
+	}
+	maximumBodyBytes, err := positiveInt64FromEnvironment(
+		"AEGISORA_SIDECAR_MAX_BODY_BYTES",
+		defaultMaximumBodyBytes,
+	)
+	if err != nil {
+		return Config{}, err
+	}
+	auditCapacity, err := positiveIntFromEnvironment(
+		"AEGISORA_SIDECAR_AUDIT_CAPACITY",
+		defaultAuditCapacity,
+	)
+	if err != nil {
+		return Config{}, err
+	}
+	decisionCacheSize, err := positiveIntFromEnvironment(
+		"AEGISORA_SIDECAR_DECISION_CACHE_SIZE",
+		defaultDecisionCacheSize,
+	)
+	if err != nil {
+		return Config{}, err
+	}
+
+	policyBundlePath := strings.TrimSpace(os.Getenv("AEGISORA_SIDECAR_POLICY_BUNDLE"))
+	policyPublicKey := os.Getenv("AEGISORA_SIDECAR_POLICY_PUBLIC_KEY")
+	if (policyBundlePath == "") != (policyPublicKey == "") {
+		return Config{}, fmt.Errorf(
+			"AEGISORA_SIDECAR_POLICY_BUNDLE and AEGISORA_SIDECAR_POLICY_PUBLIC_KEY must be configured together",
+		)
+	}
+
+	return Config{
+		HTTPAddress: environmentOrDefault(
+			"AEGISORA_SIDECAR_HTTP_ADDRESS",
+			defaultHTTPAddress,
+		),
+		ReadHeaderTimeout: readHeaderTimeout,
+		ReadTimeout:       readTimeout,
+		ShutdownTimeout:   shutdownTimeout,
+		MaximumBodyBytes:  maximumBodyBytes,
+		AuditCapacity:     auditCapacity,
+		DecisionCacheSize: decisionCacheSize,
+		PolicyBundlePath:  policyBundlePath,
+		PolicyPublicKey:   policyPublicKey,
+	}, nil
+}
+
+func environmentOrDefault(name string, fallback string) string {
+	value := strings.TrimSpace(os.Getenv(name))
+	if value == "" {
+		return fallback
+	}
+
+	return value
+}
+
+func durationFromEnvironment(name string, fallback time.Duration) (time.Duration, error) {
+	value := strings.TrimSpace(os.Getenv(name))
+	if value == "" {
+		return fallback, nil
+	}
+
+	duration, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, fmt.Errorf("parse %s: %w", name, err)
+	}
+	if duration <= 0 {
+		return 0, fmt.Errorf("%s must be greater than zero", name)
+	}
+
+	return duration, nil
+}
+
+func positiveInt64FromEnvironment(name string, fallback int64) (int64, error) {
+	value := strings.TrimSpace(os.Getenv(name))
+	if value == "" {
+		return fallback, nil
+	}
+	parsed, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse %s: %w", name, err)
+	}
+	if parsed <= 0 {
+		return 0, fmt.Errorf("%s must be greater than zero", name)
+	}
+	return parsed, nil
+}
+
+func positiveIntFromEnvironment(name string, fallback int) (int, error) {
+	parsed, err := positiveInt64FromEnvironment(name, int64(fallback))
+	if err != nil {
+		return 0, err
+	}
+	return int(parsed), nil
+}

--- a/services/sidecar/internal/config/config_test.go
+++ b/services/sidecar/internal/config/config_test.go
@@ -1,0 +1,94 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLoadDefaults(t *testing.T) {
+	t.Setenv("AEGISORA_SIDECAR_HTTP_ADDRESS", "")
+	t.Setenv("AEGISORA_SIDECAR_READ_HEADER_TIMEOUT", "")
+	t.Setenv("AEGISORA_SIDECAR_READ_TIMEOUT", "")
+	t.Setenv("AEGISORA_SIDECAR_SHUTDOWN_TIMEOUT", "")
+	t.Setenv("AEGISORA_SIDECAR_MAX_BODY_BYTES", "")
+	t.Setenv("AEGISORA_SIDECAR_AUDIT_CAPACITY", "")
+	t.Setenv("AEGISORA_SIDECAR_DECISION_CACHE_SIZE", "")
+	t.Setenv("AEGISORA_SIDECAR_POLICY_BUNDLE", "")
+	t.Setenv("AEGISORA_SIDECAR_POLICY_PUBLIC_KEY", "")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if cfg.HTTPAddress != defaultHTTPAddress {
+		t.Fatalf("HTTPAddress = %q, want %q", cfg.HTTPAddress, defaultHTTPAddress)
+	}
+	if cfg.ReadHeaderTimeout != defaultReadHeaderTimeout {
+		t.Fatalf(
+			"ReadHeaderTimeout = %s, want %s",
+			cfg.ReadHeaderTimeout,
+			defaultReadHeaderTimeout,
+		)
+	}
+	if cfg.ReadTimeout != defaultReadTimeout {
+		t.Fatalf("ReadTimeout = %s, want %s", cfg.ReadTimeout, defaultReadTimeout)
+	}
+	if cfg.ShutdownTimeout != defaultShutdownTimeout {
+		t.Fatalf(
+			"ShutdownTimeout = %s, want %s",
+			cfg.ShutdownTimeout,
+			defaultShutdownTimeout,
+		)
+	}
+	if cfg.MaximumBodyBytes != defaultMaximumBodyBytes {
+		t.Fatalf("MaximumBodyBytes = %d, want %d", cfg.MaximumBodyBytes, defaultMaximumBodyBytes)
+	}
+}
+
+func TestLoadOverrides(t *testing.T) {
+	t.Setenv("AEGISORA_SIDECAR_HTTP_ADDRESS", "127.0.0.1:9090")
+	t.Setenv("AEGISORA_SIDECAR_READ_HEADER_TIMEOUT", "2s")
+	t.Setenv("AEGISORA_SIDECAR_READ_TIMEOUT", "4s")
+	t.Setenv("AEGISORA_SIDECAR_SHUTDOWN_TIMEOUT", "3s")
+	t.Setenv("AEGISORA_SIDECAR_MAX_BODY_BYTES", "2048")
+	t.Setenv("AEGISORA_SIDECAR_AUDIT_CAPACITY", "20")
+	t.Setenv("AEGISORA_SIDECAR_DECISION_CACHE_SIZE", "30")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if cfg.HTTPAddress != "127.0.0.1:9090" {
+		t.Fatalf("HTTPAddress = %q", cfg.HTTPAddress)
+	}
+	if cfg.ReadHeaderTimeout != 2*time.Second {
+		t.Fatalf("ReadHeaderTimeout = %s", cfg.ReadHeaderTimeout)
+	}
+	if cfg.ReadTimeout != 4*time.Second {
+		t.Fatalf("ReadTimeout = %s", cfg.ReadTimeout)
+	}
+	if cfg.ShutdownTimeout != 3*time.Second {
+		t.Fatalf("ShutdownTimeout = %s", cfg.ShutdownTimeout)
+	}
+	if cfg.MaximumBodyBytes != 2048 || cfg.AuditCapacity != 20 || cfg.DecisionCacheSize != 30 {
+		t.Fatalf("numeric overrides were not applied: %#v", cfg)
+	}
+}
+
+func TestLoadRequiresPolicyPathAndKeyTogether(t *testing.T) {
+	t.Setenv("AEGISORA_SIDECAR_POLICY_BUNDLE", "/tmp/policy.json")
+	t.Setenv("AEGISORA_SIDECAR_POLICY_PUBLIC_KEY", "")
+	if _, err := Load(); err == nil {
+		t.Fatal("Load() error = nil, want paired-policy-configuration error")
+	}
+}
+
+func TestLoadRejectsInvalidDuration(t *testing.T) {
+	t.Setenv("AEGISORA_SIDECAR_READ_HEADER_TIMEOUT", "not-a-duration")
+
+	if _, err := Load(); err == nil {
+		t.Fatal("Load() error = nil, want an invalid-duration error")
+	}
+}

--- a/services/sidecar/internal/domain/conformance_test.go
+++ b/services/sidecar/internal/domain/conformance_test.go
@@ -1,0 +1,78 @@
+package domain
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+type conformanceFixtures struct {
+	Version            string     `json:"version"`
+	DecisionVocabulary []Decision `json:"decisionVocabulary"`
+	DecisionCases      []struct {
+		Name            string   `json:"name"`
+		Decision        Decision `json:"decision"`
+		ExpectedAllowed bool     `json:"expectedAllowed"`
+	} `json:"decisionCases"`
+	ValidExecutionIntent  ExecutionIntent  `json:"validExecutionIntent"`
+	ValidDecisionEnvelope DecisionEnvelope `json:"validDecisionEnvelope"`
+	ValidPolicyBundle     PolicyBundle     `json:"validPolicyBundle"`
+	ExpiredPolicyBundle   PolicyBundle     `json:"expiredPolicyBundle"`
+}
+
+func TestUpstreamSemanticFixtures(t *testing.T) {
+	fixtures := loadConformanceFixtures(t)
+	if fixtures.Version != ContractVersion {
+		t.Fatalf("fixture version = %q, want %q", fixtures.Version, ContractVersion)
+	}
+	wantVocabulary := []Decision{DecisionAllow, DecisionBlock, DecisionEscalate}
+	if len(fixtures.DecisionVocabulary) != len(wantVocabulary) {
+		t.Fatalf("decision vocabulary = %#v", fixtures.DecisionVocabulary)
+	}
+	for index, decision := range wantVocabulary {
+		if fixtures.DecisionVocabulary[index] != decision {
+			t.Fatalf("decision vocabulary[%d] = %q, want %q", index, fixtures.DecisionVocabulary[index], decision)
+		}
+	}
+	for _, test := range fixtures.DecisionCases {
+		if !test.Decision.Valid() || test.Decision.Allowed() != test.ExpectedAllowed {
+			t.Fatalf("decision case %q is not implemented canonically", test.Name)
+		}
+	}
+	if err := fixtures.ValidExecutionIntent.Validate(); err != nil {
+		t.Fatalf("validExecutionIntent: %v", err)
+	}
+	if err := fixtures.ValidDecisionEnvelope.Validate(); err != nil {
+		t.Fatalf("validDecisionEnvelope: %v", err)
+	}
+	if fixtures.ValidPolicyBundle.Scope.Tenant == "" || fixtures.ValidPolicyBundle.ExpiresAt.IsZero() {
+		t.Fatal("validPolicyBundle did not decode required canonical fields")
+	}
+	if !fixtures.ExpiredPolicyBundle.ExpiresAt.Before(fixtures.ValidPolicyBundle.ExpiresAt) {
+		t.Fatal("expired policy fixture must predate valid fixture")
+	}
+}
+
+func loadConformanceFixtures(t *testing.T) conformanceFixtures {
+	t.Helper()
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve conformance test path")
+	}
+	path := filepath.Clean(filepath.Join(
+		filepath.Dir(filename),
+		"..", "..", "..", "..",
+		"contracts", "conformance", "v1alpha1", "semantic-fixtures.json",
+	))
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var fixtures conformanceFixtures
+	if err := json.Unmarshal(contents, &fixtures); err != nil {
+		t.Fatalf("decode fixtures: %v", err)
+	}
+	return fixtures
+}

--- a/services/sidecar/internal/domain/types.go
+++ b/services/sidecar/internal/domain/types.go
@@ -1,0 +1,191 @@
+package domain
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const ContractVersion = "v1alpha1"
+
+type Decision string
+
+const (
+	DecisionAllow    Decision = "ALLOW"
+	DecisionBlock    Decision = "BLOCK"
+	DecisionEscalate Decision = "ESCALATE"
+)
+
+func (decision Decision) Valid() bool {
+	switch decision {
+	case DecisionAllow, DecisionBlock, DecisionEscalate:
+		return true
+	default:
+		return false
+	}
+}
+
+func (decision Decision) Allowed() bool {
+	return decision == DecisionAllow
+}
+
+type CapabilityRequest struct {
+	Capability string `json:"capability"`
+	Provider   string `json:"provider,omitempty"`
+	Model      string `json:"model,omitempty"`
+	Route      string `json:"route,omitempty"`
+}
+
+type ExecutionIntent struct {
+	RequestID         string                     `json:"request_id"`
+	CorrelationID     string                     `json:"correlation_id,omitempty"`
+	AgentClaim        string                     `json:"agent_claim"`
+	CapabilityRequest CapabilityRequest          `json:"capability_request"`
+	Input             map[string]json.RawMessage `json:"input"`
+	Context           map[string]json.RawMessage `json:"context"`
+}
+
+func (intent ExecutionIntent) Validate() error {
+	var validationErrors []error
+
+	validateRequiredString := func(field string, value string, maximum int) {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			validationErrors = append(validationErrors, fmt.Errorf("%s is required", field))
+			return
+		}
+		if len(value) > maximum {
+			validationErrors = append(validationErrors, fmt.Errorf("%s exceeds %d bytes", field, maximum))
+		}
+	}
+
+	validateOptionalString := func(field string, value string, maximum int) {
+		if len(value) > maximum {
+			validationErrors = append(validationErrors, fmt.Errorf("%s exceeds %d bytes", field, maximum))
+		}
+	}
+
+	validateRequiredString("request_id", intent.RequestID, 256)
+	validateOptionalString("correlation_id", intent.CorrelationID, 256)
+	validateRequiredString("agent_claim", intent.AgentClaim, 256)
+	validateRequiredString("capability_request.capability", intent.CapabilityRequest.Capability, 256)
+	validateOptionalString("capability_request.provider", intent.CapabilityRequest.Provider, 128)
+	validateOptionalString("capability_request.model", intent.CapabilityRequest.Model, 256)
+	validateOptionalString("capability_request.route", intent.CapabilityRequest.Route, 1024)
+
+	if intent.Input == nil {
+		validationErrors = append(validationErrors, errors.New("input must be an object"))
+	}
+	if intent.Context == nil {
+		validationErrors = append(validationErrors, errors.New("context must be an object"))
+	}
+
+	return errors.Join(validationErrors...)
+}
+
+type Risk struct {
+	Score   int      `json:"score"`
+	Level   string   `json:"level,omitempty"`
+	Signals []string `json:"signals,omitempty"`
+}
+
+type DecisionEnvelope struct {
+	DecisionID    string    `json:"decision_id"`
+	RequestID     string    `json:"request_id"`
+	CorrelationID string    `json:"correlation_id"`
+	Decision      Decision  `json:"decision"`
+	Allowed       bool      `json:"allowed"`
+	ReasonCode    string    `json:"reason_code"`
+	Risk          Risk      `json:"risk"`
+	PolicyVersion string    `json:"policy_version"`
+	PolicyDigest  string    `json:"policy_digest"`
+	EvaluatedAt   time.Time `json:"evaluated_at"`
+}
+
+func NewDecisionEnvelope(
+	decisionID string,
+	requestID string,
+	correlationID string,
+	decision Decision,
+	reasonCode string,
+	risk Risk,
+	policyVersion string,
+	policyDigest string,
+	evaluatedAt time.Time,
+) DecisionEnvelope {
+	return DecisionEnvelope{
+		DecisionID:    decisionID,
+		RequestID:     requestID,
+		CorrelationID: correlationID,
+		Decision:      decision,
+		Allowed:       decision.Allowed(),
+		ReasonCode:    reasonCode,
+		Risk:          risk,
+		PolicyVersion: policyVersion,
+		PolicyDigest:  policyDigest,
+		EvaluatedAt:   evaluatedAt.UTC(),
+	}
+}
+
+func (envelope DecisionEnvelope) Validate() error {
+	if !envelope.Decision.Valid() {
+		return fmt.Errorf("invalid decision %q", envelope.Decision)
+	}
+	if envelope.Allowed != envelope.Decision.Allowed() {
+		return errors.New("allowed must be derived from decision")
+	}
+	for field, value := range map[string]string{
+		"decision_id":    envelope.DecisionID,
+		"request_id":     envelope.RequestID,
+		"correlation_id": envelope.CorrelationID,
+		"reason_code":    envelope.ReasonCode,
+		"policy_version": envelope.PolicyVersion,
+		"policy_digest":  envelope.PolicyDigest,
+	} {
+		if strings.TrimSpace(value) == "" {
+			return fmt.Errorf("%s is required", field)
+		}
+	}
+	if envelope.EvaluatedAt.IsZero() {
+		return errors.New("evaluated_at is required")
+	}
+	if envelope.Risk.Score < 0 || envelope.Risk.Score > 100 {
+		return errors.New("risk.score must be between 0 and 100")
+	}
+	return nil
+}
+
+type PolicyScope struct {
+	Tenant     string `json:"tenant"`
+	Agent      string `json:"agent,omitempty"`
+	Capability string `json:"capability,omitempty"`
+}
+
+type PolicyBundle struct {
+	BundleID  string          `json:"bundle_id"`
+	Scope     PolicyScope     `json:"scope"`
+	Version   string          `json:"version"`
+	Digest    string          `json:"digest"`
+	ExpiresAt time.Time       `json:"expires_at"`
+	Signature string          `json:"signature"`
+	Policy    json.RawMessage `json:"policy"`
+}
+
+type ActivePolicyVersion struct {
+	Version   string    `json:"version"`
+	Digest    string    `json:"digest"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+type AuditEvent struct {
+	EventID       string                     `json:"event_id"`
+	RequestID     string                     `json:"request_id"`
+	CorrelationID string                     `json:"correlation_id"`
+	DecisionID    string                     `json:"decision_id"`
+	PolicyVersion string                     `json:"policy_version"`
+	EventType     string                     `json:"event_type"`
+	OccurredAt    time.Time                  `json:"occurred_at"`
+	Payload       map[string]json.RawMessage `json:"payload,omitempty"`
+}

--- a/services/sidecar/internal/domain/types_test.go
+++ b/services/sidecar/internal/domain/types_test.go
@@ -1,0 +1,75 @@
+package domain
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestDecisionVocabularyAndAllowedDerivation(t *testing.T) {
+	tests := []struct {
+		decision Decision
+		allowed  bool
+	}{
+		{DecisionAllow, true},
+		{DecisionBlock, false},
+		{DecisionEscalate, false},
+	}
+
+	for _, test := range tests {
+		t.Run(string(test.decision), func(t *testing.T) {
+			if !test.decision.Valid() {
+				t.Fatalf("%s must be valid", test.decision)
+			}
+			if got := test.decision.Allowed(); got != test.allowed {
+				t.Fatalf("Allowed() = %t, want %t", got, test.allowed)
+			}
+		})
+	}
+
+	if Decision("UNKNOWN").Valid() {
+		t.Fatal("UNKNOWN must not be valid")
+	}
+}
+
+func TestExecutionIntentValidation(t *testing.T) {
+	valid := ExecutionIntent{
+		RequestID:         "req-1",
+		AgentClaim:        "agent:demo",
+		CapabilityRequest: CapabilityRequest{Capability: "provider.generate"},
+		Input:             map[string]json.RawMessage{},
+		Context:           map[string]json.RawMessage{},
+	}
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("valid intent: %v", err)
+	}
+
+	invalid := valid
+	invalid.RequestID = ""
+	invalid.Input = nil
+	if err := invalid.Validate(); err == nil {
+		t.Fatal("invalid intent must fail validation")
+	}
+}
+
+func TestDecisionEnvelopeRejectsAllowedMismatch(t *testing.T) {
+	envelope := NewDecisionEnvelope(
+		"dec-1",
+		"req-1",
+		"corr-1",
+		DecisionBlock,
+		"POLICY_BLOCK",
+		Risk{Score: 100},
+		"policy-1",
+		"sha256:test",
+		time.Now(),
+	)
+	if err := envelope.Validate(); err != nil {
+		t.Fatalf("valid envelope: %v", err)
+	}
+
+	envelope.Allowed = true
+	if err := envelope.Validate(); err == nil {
+		t.Fatal("allowed/decision mismatch must fail validation")
+	}
+}

--- a/services/sidecar/internal/engine/engine.go
+++ b/services/sidecar/internal/engine/engine.go
@@ -1,0 +1,293 @@
+package engine
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/aegisora-ai/aegisora/services/sidecar/internal/audit"
+	"github.com/aegisora-ai/aegisora/services/sidecar/internal/domain"
+	"github.com/aegisora-ai/aegisora/services/sidecar/internal/policy"
+)
+
+const (
+	missingPolicyVersion = "none"
+	missingPolicyDigest  = "sha256:none"
+)
+
+type PolicyProvider interface {
+	Active(time.Time) (policy.Snapshot, bool)
+}
+
+type Clock func() time.Time
+type IDSource func() string
+
+type Options struct {
+	Policies     PolicyProvider
+	Audit        audit.Sink
+	Clock        Clock
+	IDs          IDSource
+	CacheEntries int
+}
+
+type cachedDecision struct {
+	intentDigest string
+	envelope     domain.DecisionEnvelope
+}
+
+type requestLock struct {
+	mu   sync.Mutex
+	refs int
+}
+
+type Engine struct {
+	policies PolicyProvider
+	audit    audit.Sink
+	clock    Clock
+	ids      IDSource
+
+	cacheMu      sync.Mutex
+	cacheEntries int
+	cache        map[string]cachedDecision
+	cacheOrder   []string
+
+	requestLocksMu sync.Mutex
+	requestLocks   map[string]*requestLock
+}
+
+func New(options Options) (*Engine, error) {
+	if options.Policies == nil {
+		return nil, errors.New("policy provider is required")
+	}
+	if options.Audit == nil {
+		return nil, errors.New("audit sink is required")
+	}
+	if options.Clock == nil {
+		options.Clock = time.Now
+	}
+	if options.IDs == nil {
+		options.IDs = randomID
+	}
+	if options.CacheEntries == 0 {
+		options.CacheEntries = 10_000
+	}
+	if options.CacheEntries < 0 {
+		return nil, errors.New("cache entries must not be negative")
+	}
+	return &Engine{
+		policies:     options.Policies,
+		audit:        options.Audit,
+		clock:        options.Clock,
+		ids:          options.IDs,
+		cacheEntries: options.CacheEntries,
+		cache:        make(map[string]cachedDecision),
+		requestLocks: make(map[string]*requestLock),
+	}, nil
+}
+
+func (engine *Engine) Evaluate(ctx context.Context, intent domain.ExecutionIntent) (domain.DecisionEnvelope, error) {
+	now := engine.clock().UTC()
+	correlationID := intent.CorrelationID
+	if correlationID == "" {
+		correlationID = engine.ids()
+	}
+
+	intentDigest, err := hashIntent(intent)
+	if err != nil {
+		return domain.DecisionEnvelope{}, fmt.Errorf("hash execution intent: %w", err)
+	}
+	if intent.RequestID != "" {
+		release := engine.lockRequest(intent.RequestID)
+		defer release()
+	}
+	snapshot, hasPolicy := engine.policies.Active(now)
+	if intent.RequestID != "" {
+		if cached, exists := engine.cached(intent.RequestID); exists {
+			if cached.intentDigest != intentDigest {
+				return engine.finish(ctx, intent, correlationID, snapshot, policy.Evaluation{
+					Decision:   domain.DecisionBlock,
+					ReasonCode: "REQUEST_ID_CONFLICT",
+					Risk:       domain.Risk{Score: 100, Level: "HIGH"},
+				}, now, hasPolicy)
+			}
+			if cacheMatchesPolicy(cached, snapshot, hasPolicy) {
+				return cached.envelope, nil
+			}
+		}
+	}
+
+	if validationErr := intent.Validate(); validationErr != nil {
+		envelope, finishErr := engine.finish(ctx, intent, correlationID, snapshot, policy.Evaluation{
+			Decision:   domain.DecisionBlock,
+			ReasonCode: "INVALID_EXECUTION_INTENT",
+			Risk: domain.Risk{
+				Score:   100,
+				Level:   "HIGH",
+				Signals: []string{validationErr.Error()},
+			},
+		}, now, hasPolicy)
+		if finishErr == nil {
+			engine.store(intent.RequestID, intentDigest, envelope)
+		}
+		return envelope, finishErr
+	}
+
+	if !hasPolicy {
+		envelope, finishErr := engine.finish(ctx, intent, correlationID, policy.Snapshot{}, policy.Evaluation{
+			Decision:   domain.DecisionBlock,
+			ReasonCode: "POLICY_UNAVAILABLE",
+			Risk:       domain.Risk{Score: 100, Level: "HIGH"},
+		}, now, false)
+		if finishErr == nil {
+			engine.store(intent.RequestID, intentDigest, envelope)
+		}
+		return envelope, finishErr
+	}
+
+	evaluation := policy.Evaluate(snapshot, intent)
+	envelope, finishErr := engine.finish(ctx, intent, correlationID, snapshot, evaluation, now, true)
+	if finishErr == nil {
+		engine.store(intent.RequestID, intentDigest, envelope)
+	}
+	return envelope, finishErr
+}
+
+func (engine *Engine) lockRequest(requestID string) func() {
+	engine.requestLocksMu.Lock()
+	lock := engine.requestLocks[requestID]
+	if lock == nil {
+		lock = &requestLock{}
+		engine.requestLocks[requestID] = lock
+	}
+	lock.refs++
+	engine.requestLocksMu.Unlock()
+
+	lock.mu.Lock()
+	return func() {
+		lock.mu.Unlock()
+		engine.requestLocksMu.Lock()
+		lock.refs--
+		if lock.refs == 0 {
+			delete(engine.requestLocks, requestID)
+		}
+		engine.requestLocksMu.Unlock()
+	}
+}
+
+func (engine *Engine) finish(
+	ctx context.Context,
+	intent domain.ExecutionIntent,
+	correlationID string,
+	snapshot policy.Snapshot,
+	evaluation policy.Evaluation,
+	now time.Time,
+	hasPolicy bool,
+) (domain.DecisionEnvelope, error) {
+	version := missingPolicyVersion
+	digest := missingPolicyDigest
+	requestID := intent.RequestID
+	if requestID == "" {
+		requestID = "invalid:" + correlationID
+	}
+	if hasPolicy {
+		version = snapshot.Bundle.Version
+		digest = snapshot.Bundle.Digest
+	}
+
+	envelope := domain.NewDecisionEnvelope(
+		engine.ids(),
+		requestID,
+		correlationID,
+		evaluation.Decision,
+		evaluation.ReasonCode,
+		evaluation.Risk,
+		version,
+		digest,
+		now,
+	)
+	if err := envelope.Validate(); err != nil {
+		return domain.DecisionEnvelope{}, fmt.Errorf("invalid decision envelope: %w", err)
+	}
+
+	event := domain.AuditEvent{
+		EventID:       engine.ids(),
+		RequestID:     envelope.RequestID,
+		CorrelationID: envelope.CorrelationID,
+		DecisionID:    envelope.DecisionID,
+		PolicyVersion: envelope.PolicyVersion,
+		EventType:     "decision.evaluated",
+		OccurredAt:    now,
+	}
+	if err := engine.audit.Append(ctx, event); err != nil {
+		return domain.DecisionEnvelope{}, fmt.Errorf("append decision audit event: %w", err)
+	}
+	return envelope, nil
+}
+
+func (engine *Engine) cached(requestID string) (cachedDecision, bool) {
+	engine.cacheMu.Lock()
+	defer engine.cacheMu.Unlock()
+	value, exists := engine.cache[requestID]
+	value.envelope = cloneEnvelope(value.envelope)
+	return value, exists
+}
+
+func (engine *Engine) store(requestID string, intentDigest string, envelope domain.DecisionEnvelope) {
+	if requestID == "" || engine.cacheEntries == 0 {
+		return
+	}
+	engine.cacheMu.Lock()
+	defer engine.cacheMu.Unlock()
+	value := cachedDecision{intentDigest: intentDigest, envelope: cloneEnvelope(envelope)}
+	if _, exists := engine.cache[requestID]; exists {
+		engine.cache[requestID] = value
+		return
+	}
+	if len(engine.cacheOrder) == engine.cacheEntries {
+		oldest := engine.cacheOrder[0]
+		delete(engine.cache, oldest)
+		engine.cacheOrder = engine.cacheOrder[1:]
+	}
+	engine.cache[requestID] = value
+	engine.cacheOrder = append(engine.cacheOrder, requestID)
+}
+
+func cacheMatchesPolicy(cached cachedDecision, snapshot policy.Snapshot, hasPolicy bool) bool {
+	if !hasPolicy {
+		return cached.envelope.PolicyVersion == missingPolicyVersion &&
+			cached.envelope.PolicyDigest == missingPolicyDigest
+	}
+	return cached.envelope.PolicyVersion == snapshot.Bundle.Version &&
+		cached.envelope.PolicyDigest == snapshot.Bundle.Digest
+}
+
+func cloneEnvelope(envelope domain.DecisionEnvelope) domain.DecisionEnvelope {
+	cloned := envelope
+	cloned.Risk.Signals = append([]string(nil), envelope.Risk.Signals...)
+	return cloned
+}
+
+func hashIntent(intent domain.ExecutionIntent) (string, error) {
+	encoded, err := json.Marshal(intent)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(encoded)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+func randomID() string {
+	bytes := make([]byte, 16)
+	if _, err := rand.Read(bytes); err != nil {
+		panic(fmt.Sprintf("generate secure identifier: %v", err))
+	}
+	bytes[6] = (bytes[6] & 0x0f) | 0x40
+	bytes[8] = (bytes[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%x-%x-%x-%x-%x", bytes[0:4], bytes[4:6], bytes[6:8], bytes[8:10], bytes[10:16])
+}

--- a/services/sidecar/internal/engine/engine_test.go
+++ b/services/sidecar/internal/engine/engine_test.go
@@ -1,0 +1,253 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aegisora-ai/aegisora/services/sidecar/internal/audit"
+	"github.com/aegisora-ai/aegisora/services/sidecar/internal/domain"
+	"github.com/aegisora-ai/aegisora/services/sidecar/internal/policy"
+)
+
+type staticPolicies struct {
+	snapshot policy.Snapshot
+	ready    bool
+}
+
+func (policies staticPolicies) Active(time.Time) (policy.Snapshot, bool) {
+	return policies.snapshot, policies.ready
+}
+
+type mutablePolicies struct {
+	snapshot policy.Snapshot
+	ready    bool
+}
+
+func (policies *mutablePolicies) Active(time.Time) (policy.Snapshot, bool) {
+	return policies.snapshot, policies.ready
+}
+
+func testEngine(t *testing.T, snapshot policy.Snapshot, ready bool) (*Engine, *audit.MemorySink) {
+	t.Helper()
+	sink, _ := audit.NewMemorySink(100)
+	nextID := 0
+	instance, err := New(Options{
+		Policies: staticPolicies{snapshot: snapshot, ready: ready},
+		Audit:    sink,
+		Clock:    func() time.Time { return time.Date(2026, 8, 29, 12, 0, 0, 0, time.UTC) },
+		IDs: func() string {
+			nextID++
+			return "id-" + string(rune('0'+nextID))
+		},
+		CacheEntries: 10,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return instance, sink
+}
+
+func validIntent() domain.ExecutionIntent {
+	return domain.ExecutionIntent{
+		RequestID:     "req-1",
+		CorrelationID: "corr-1",
+		AgentClaim:    "agent:demo",
+		CapabilityRequest: domain.CapabilityRequest{
+			Capability: "provider.generate",
+		},
+		Input:   map[string]json.RawMessage{},
+		Context: map[string]json.RawMessage{},
+	}
+}
+
+func TestEvaluateFailsClosedWithoutPolicy(t *testing.T) {
+	instance, sink := testEngine(t, policy.Snapshot{}, false)
+	envelope, err := instance.Evaluate(context.Background(), validIntent())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if envelope.Decision != domain.DecisionBlock || envelope.ReasonCode != "POLICY_UNAVAILABLE" {
+		t.Fatalf("Evaluate() = %#v", envelope)
+	}
+	if envelope.Allowed {
+		t.Fatal("BLOCK must derive allowed=false")
+	}
+	if len(sink.Events()) != 1 || sink.Events()[0].DecisionID != envelope.DecisionID {
+		t.Fatalf("audit events = %#v", sink.Events())
+	}
+}
+
+func TestEvaluateIsIdempotentAndRejectsConflict(t *testing.T) {
+	snapshot := policy.Snapshot{
+		Bundle: domain.PolicyBundle{Version: "policy-1", Digest: "sha256:test"},
+		Document: policy.Document{
+			DefaultDecision: domain.DecisionAllow,
+			Rules:           []policy.Rule{},
+		},
+	}
+	instance, sink := testEngine(t, snapshot, true)
+	first, err := instance.Evaluate(context.Background(), validIntent())
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := instance.Evaluate(context.Background(), validIntent())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.DecisionID != second.DecisionID {
+		t.Fatalf("idempotent decisions differ: %q != %q", first.DecisionID, second.DecisionID)
+	}
+	if len(sink.Events()) != 1 {
+		t.Fatalf("idempotent replay emitted %d audit events, want 1", len(sink.Events()))
+	}
+
+	conflict := validIntent()
+	conflict.CapabilityRequest.Provider = "attacker"
+	result, err := instance.Evaluate(context.Background(), conflict)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Decision != domain.DecisionBlock || result.ReasonCode != "REQUEST_ID_CONFLICT" {
+		t.Fatalf("conflict result = %#v", result)
+	}
+}
+
+func TestEvaluateReevaluatesCachedRequestWhenPolicyChanges(t *testing.T) {
+	sink, _ := audit.NewMemorySink(100)
+	policies := &mutablePolicies{
+		ready: true,
+		snapshot: policy.Snapshot{
+			Bundle: domain.PolicyBundle{Version: "policy-1", Digest: "sha256:one"},
+			Document: policy.Document{
+				DefaultDecision: domain.DecisionAllow,
+			},
+		},
+	}
+	nextID := 0
+	instance, err := New(Options{
+		Policies: policies,
+		Audit:    sink,
+		Clock:    func() time.Time { return time.Date(2026, 8, 29, 12, 0, 0, 0, time.UTC) },
+		IDs: func() string {
+			nextID++
+			return "id-" + string(rune('0'+nextID))
+		},
+		CacheEntries: 10,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	allowed, err := instance.Evaluate(context.Background(), validIntent())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if allowed.Decision != domain.DecisionAllow {
+		t.Fatalf("first decision = %q, want ALLOW", allowed.Decision)
+	}
+
+	policies.ready = false
+	blocked, err := instance.Evaluate(context.Background(), validIntent())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if blocked.Decision != domain.DecisionBlock || blocked.ReasonCode != "POLICY_UNAVAILABLE" {
+		t.Fatalf("decision after policy removal = %#v", blocked)
+	}
+	if blocked.DecisionID == allowed.DecisionID {
+		t.Fatal("policy removal reused the cached ALLOW decision")
+	}
+
+	replayed, err := instance.Evaluate(context.Background(), validIntent())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if replayed.DecisionID != blocked.DecisionID {
+		t.Fatalf("stable policy state did not replay decision: %q != %q", replayed.DecisionID, blocked.DecisionID)
+	}
+	if len(sink.Events()) != 2 {
+		t.Fatalf("audit events = %d, want 2", len(sink.Events()))
+	}
+}
+
+func TestEvaluateCacheIsolatesRiskSignals(t *testing.T) {
+	snapshot := policy.Snapshot{
+		Bundle: domain.PolicyBundle{Version: "policy-1", Digest: "sha256:test"},
+		Document: policy.Document{
+			DefaultDecision: domain.DecisionBlock,
+			Rules: []policy.Rule{{
+				Capability: "provider.generate",
+				Decision:   domain.DecisionEscalate,
+				ReasonCode: "REVIEW_REQUIRED",
+				Risk:       &domain.Risk{Score: 70, Level: "HIGH", Signals: []string{"original"}},
+			}},
+		},
+	}
+	instance, _ := testEngine(t, snapshot, true)
+
+	first, err := instance.Evaluate(context.Background(), validIntent())
+	if err != nil {
+		t.Fatal(err)
+	}
+	first.Risk.Signals[0] = "mutated"
+
+	second, err := instance.Evaluate(context.Background(), validIntent())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := second.Risk.Signals[0]; got != "original" {
+		t.Fatalf("cached risk signal = %q, want isolated original", got)
+	}
+}
+
+func TestEvaluateSerializesConcurrentIdempotentRequests(t *testing.T) {
+	snapshot := policy.Snapshot{
+		Bundle: domain.PolicyBundle{Version: "policy-1", Digest: "sha256:test"},
+		Document: policy.Document{
+			DefaultDecision: domain.DecisionAllow,
+			Rules:           []policy.Rule{},
+		},
+	}
+	instance, sink := testEngine(t, snapshot, true)
+
+	const callers = 20
+	results := make(chan domain.DecisionEnvelope, callers)
+	errors := make(chan error, callers)
+	start := make(chan struct{})
+	var wait sync.WaitGroup
+	wait.Add(callers)
+	for range callers {
+		go func() {
+			defer wait.Done()
+			<-start
+			result, err := instance.Evaluate(context.Background(), validIntent())
+			results <- result
+			errors <- err
+		}()
+	}
+	close(start)
+	wait.Wait()
+	close(results)
+	close(errors)
+
+	for err := range errors {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	decisionID := ""
+	for result := range results {
+		if decisionID == "" {
+			decisionID = result.DecisionID
+		}
+		if result.DecisionID != decisionID {
+			t.Fatalf("concurrent replay returned decision %q, want %q", result.DecisionID, decisionID)
+		}
+	}
+	if len(sink.Events()) != 1 {
+		t.Fatalf("audit events = %d, want 1", len(sink.Events()))
+	}
+}

--- a/services/sidecar/internal/httpapi/handler.go
+++ b/services/sidecar/internal/httpapi/handler.go
@@ -1,0 +1,197 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"mime"
+	"net/http"
+
+	"github.com/aegisora-ai/aegisora/services/sidecar/internal/domain"
+)
+
+const defaultMaximumBodyBytes = int64(1 << 20)
+
+type Evaluator interface {
+	Evaluate(context.Context, domain.ExecutionIntent) (domain.DecisionEnvelope, error)
+}
+
+type Options struct {
+	ServiceName      string
+	Version          string
+	Commit           string
+	Ready            func() bool
+	ActivePolicy     func() (domain.ActivePolicyVersion, bool)
+	Evaluator        Evaluator
+	MaximumBodyBytes int64
+}
+
+type Handler struct {
+	serviceName      string
+	version          string
+	commit           string
+	ready            func() bool
+	activePolicy     func() (domain.ActivePolicyVersion, bool)
+	evaluator        Evaluator
+	maximumBodyBytes int64
+	mux              *http.ServeMux
+}
+
+func New(options Options) *Handler {
+	if options.ServiceName == "" {
+		options.ServiceName = "aegisora-sidecar"
+	}
+	if options.Version == "" {
+		options.Version = "dev"
+	}
+	if options.Commit == "" {
+		options.Commit = "unknown"
+	}
+	if options.Ready == nil {
+		options.Ready = func() bool { return false }
+	}
+	if options.ActivePolicy == nil {
+		options.ActivePolicy = func() (domain.ActivePolicyVersion, bool) {
+			return domain.ActivePolicyVersion{}, false
+		}
+	}
+	if options.MaximumBodyBytes <= 0 {
+		options.MaximumBodyBytes = defaultMaximumBodyBytes
+	}
+
+	handler := &Handler{
+		serviceName:      options.ServiceName,
+		version:          options.Version,
+		commit:           options.Commit,
+		ready:            options.Ready,
+		activePolicy:     options.ActivePolicy,
+		evaluator:        options.Evaluator,
+		maximumBodyBytes: options.MaximumBodyBytes,
+		mux:              http.NewServeMux(),
+	}
+	handler.routes()
+	return handler
+}
+
+func (handler *Handler) ServeHTTP(response http.ResponseWriter, request *http.Request) {
+	response.Header().Set("X-Content-Type-Options", "nosniff")
+	handler.mux.ServeHTTP(response, request)
+}
+
+func (handler *Handler) routes() {
+	handler.mux.HandleFunc("GET /healthz", handler.legacyHealth)
+	handler.mux.HandleFunc("GET /readyz", handler.readiness)
+	handler.mux.HandleFunc("GET /v1alpha1/health", handler.health)
+	handler.mux.HandleFunc("GET /v1alpha1/readiness", handler.readiness)
+	handler.mux.HandleFunc("GET /v1alpha1/policies/active", handler.getActivePolicy)
+	handler.mux.HandleFunc("POST /v1alpha1/execution/intent", handler.submitExecutionIntent)
+}
+
+func (handler *Handler) legacyHealth(response http.ResponseWriter, _ *http.Request) {
+	writeJSON(response, http.StatusOK, map[string]any{
+		"status":           "ok",
+		"service":          handler.serviceName,
+		"version":          handler.version,
+		"commit":           handler.commit,
+		"contract_version": domain.ContractVersion,
+	})
+}
+
+func (handler *Handler) health(response http.ResponseWriter, _ *http.Request) {
+	writeJSON(response, http.StatusOK, map[string]string{
+		"status":           "healthy",
+		"contract_version": domain.ContractVersion,
+	})
+}
+
+func (handler *Handler) readiness(response http.ResponseWriter, _ *http.Request) {
+	if !handler.ready() {
+		writeJSON(response, http.StatusServiceUnavailable, map[string]string{
+			"status":           "not_ready",
+			"contract_version": domain.ContractVersion,
+		})
+		return
+	}
+	writeJSON(response, http.StatusOK, map[string]string{
+		"status":           "ready",
+		"contract_version": domain.ContractVersion,
+	})
+}
+
+func (handler *Handler) getActivePolicy(response http.ResponseWriter, _ *http.Request) {
+	active, ok := handler.activePolicy()
+	if !ok {
+		writeError(response, http.StatusServiceUnavailable, "POLICY_UNAVAILABLE", "no valid policy bundle is active")
+		return
+	}
+	writeJSON(response, http.StatusOK, active)
+}
+
+func (handler *Handler) submitExecutionIntent(response http.ResponseWriter, request *http.Request) {
+	if handler.evaluator == nil {
+		writeError(response, http.StatusServiceUnavailable, "ENGINE_UNAVAILABLE", "the enforcement engine is unavailable")
+		return
+	}
+	mediaType, _, err := mime.ParseMediaType(request.Header.Get("Content-Type"))
+	if err != nil || mediaType != "application/json" {
+		writeError(response, http.StatusUnsupportedMediaType, "UNSUPPORTED_CONTENT_TYPE", "Content-Type must be application/json")
+		return
+	}
+
+	request.Body = http.MaxBytesReader(response, request.Body, handler.maximumBodyBytes)
+	decoder := json.NewDecoder(request.Body)
+	decoder.DisallowUnknownFields()
+	var intent domain.ExecutionIntent
+	if err := decoder.Decode(&intent); err != nil {
+		status := http.StatusBadRequest
+		var maximumBytesError *http.MaxBytesError
+		if errors.As(err, &maximumBytesError) {
+			status = http.StatusRequestEntityTooLarge
+		}
+		writeError(response, status, "INVALID_JSON", err.Error())
+		return
+	}
+	if err := ensureEndOfBody(decoder); err != nil {
+		writeError(response, http.StatusBadRequest, "INVALID_JSON", err.Error())
+		return
+	}
+	if err := intent.Validate(); err != nil {
+		writeError(response, http.StatusBadRequest, "INVALID_EXECUTION_INTENT", err.Error())
+		return
+	}
+
+	decision, err := handler.evaluator.Evaluate(request.Context(), intent)
+	if err != nil {
+		writeError(response, http.StatusInternalServerError, "ENFORCEMENT_FAILURE", "the decision could not be safely recorded")
+		return
+	}
+	writeJSON(response, http.StatusOK, decision)
+}
+
+func ensureEndOfBody(decoder *json.Decoder) error {
+	var trailing any
+	err := decoder.Decode(&trailing)
+	if errors.Is(err, io.EOF) {
+		return nil
+	}
+	if err == nil {
+		return errors.New("request body must contain exactly one JSON object")
+	}
+	return err
+}
+
+func writeError(response http.ResponseWriter, status int, code string, message string) {
+	writeJSON(response, status, map[string]any{
+		"error": map[string]string{
+			"code":    code,
+			"message": message,
+		},
+	})
+}
+
+func writeJSON(response http.ResponseWriter, status int, value any) {
+	response.Header().Set("Content-Type", "application/json")
+	response.WriteHeader(status)
+	_ = json.NewEncoder(response).Encode(value)
+}

--- a/services/sidecar/internal/httpapi/handler_test.go
+++ b/services/sidecar/internal/httpapi/handler_test.go
@@ -1,0 +1,115 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aegisora-ai/aegisora/services/sidecar/internal/domain"
+)
+
+type evaluatorStub struct {
+	decision domain.DecisionEnvelope
+	calls    int
+}
+
+func (stub *evaluatorStub) Evaluate(_ context.Context, _ domain.ExecutionIntent) (domain.DecisionEnvelope, error) {
+	stub.calls++
+	return stub.decision, nil
+}
+
+func TestHealthEndpoints(t *testing.T) {
+	handler := New(Options{ServiceName: "test-sidecar", Version: "test-version", Commit: "test-commit"})
+
+	legacy := httptest.NewRecorder()
+	handler.ServeHTTP(legacy, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+	if legacy.Code != http.StatusOK || !strings.Contains(legacy.Body.String(), "test-sidecar") {
+		t.Fatalf("legacy health = %d %s", legacy.Code, legacy.Body.String())
+	}
+
+	contract := httptest.NewRecorder()
+	handler.ServeHTTP(contract, httptest.NewRequest(http.MethodGet, "/v1alpha1/health", nil))
+	var body map[string]string
+	if err := json.NewDecoder(contract.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if body["status"] != "healthy" || body["contract_version"] != domain.ContractVersion {
+		t.Fatalf("contract health = %#v", body)
+	}
+}
+
+func TestReadinessAndActivePolicy(t *testing.T) {
+	expires := time.Now().Add(time.Hour).UTC()
+	handler := New(Options{
+		Ready: func() bool { return true },
+		ActivePolicy: func() (domain.ActivePolicyVersion, bool) {
+			return domain.ActivePolicyVersion{Version: "policy-1", Digest: "sha256:test", ExpiresAt: expires}, true
+		},
+	})
+
+	ready := httptest.NewRecorder()
+	handler.ServeHTTP(ready, httptest.NewRequest(http.MethodGet, "/v1alpha1/readiness", nil))
+	if ready.Code != http.StatusOK {
+		t.Fatalf("readiness status = %d", ready.Code)
+	}
+
+	active := httptest.NewRecorder()
+	handler.ServeHTTP(active, httptest.NewRequest(http.MethodGet, "/v1alpha1/policies/active", nil))
+	if active.Code != http.StatusOK || !strings.Contains(active.Body.String(), "policy-1") {
+		t.Fatalf("active policy = %d %s", active.Code, active.Body.String())
+	}
+}
+
+func TestSubmitExecutionIntent(t *testing.T) {
+	stub := &evaluatorStub{decision: domain.NewDecisionEnvelope(
+		"dec-1", "req-1", "corr-1", domain.DecisionAllow, "POLICY_ALLOW",
+		domain.Risk{Score: 0}, "policy-1", "sha256:test", time.Now(),
+	)}
+	handler := New(Options{Evaluator: stub})
+	request := httptest.NewRequest(http.MethodPost, "/v1alpha1/execution/intent", strings.NewReader(`{
+		"request_id":"req-1",
+		"agent_claim":"agent:demo",
+		"capability_request":{"capability":"provider.generate"},
+		"input":{},
+		"context":{}
+	}`))
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK || stub.calls != 1 {
+		t.Fatalf("response = %d %s, calls = %d", response.Code, response.Body.String(), stub.calls)
+	}
+	var body domain.DecisionEnvelope
+	if err := json.NewDecoder(response.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if body.Decision != domain.DecisionAllow || !body.Allowed {
+		t.Fatalf("decision = %#v", body)
+	}
+}
+
+func TestSubmitRejectsUnknownFieldAndOversizedBody(t *testing.T) {
+	stub := &evaluatorStub{}
+	handler := New(Options{Evaluator: stub, MaximumBodyBytes: 64})
+
+	unknown := httptest.NewRequest(http.MethodPost, "/v1alpha1/execution/intent", strings.NewReader(`{"unknown":true}`))
+	unknown.Header.Set("Content-Type", "application/json")
+	unknownResponse := httptest.NewRecorder()
+	handler.ServeHTTP(unknownResponse, unknown)
+	if unknownResponse.Code != http.StatusBadRequest || stub.calls != 0 {
+		t.Fatalf("unknown response = %d %s", unknownResponse.Code, unknownResponse.Body.String())
+	}
+
+	large := httptest.NewRequest(http.MethodPost, "/v1alpha1/execution/intent", strings.NewReader(`{"request_id":"`+strings.Repeat("x", 200)+`"}`))
+	large.Header.Set("Content-Type", "application/json")
+	largeResponse := httptest.NewRecorder()
+	handler.ServeHTTP(largeResponse, large)
+	if largeResponse.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("large response = %d %s", largeResponse.Code, largeResponse.Body.String())
+	}
+}

--- a/services/sidecar/internal/httpapi/integration_test.go
+++ b/services/sidecar/internal/httpapi/integration_test.go
@@ -1,0 +1,116 @@
+package httpapi
+
+import (
+	"crypto/ed25519"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aegisora-ai/aegisora/services/sidecar/internal/audit"
+	"github.com/aegisora-ai/aegisora/services/sidecar/internal/domain"
+	"github.com/aegisora-ai/aegisora/services/sidecar/internal/engine"
+	"github.com/aegisora-ai/aegisora/services/sidecar/internal/policy"
+)
+
+func TestEndToEndDecisionMatrix(t *testing.T) {
+	now := time.Date(2026, 8, 29, 12, 0, 0, 0, time.UTC)
+	privateKey := ed25519.NewKeyFromSeed([]byte("0123456789abcdef0123456789abcdef"))
+	publicKey := privateKey.Public().(ed25519.PublicKey)
+	verifier, err := policy.NewEd25519Verifier(policy.EncodePublicKey(publicKey))
+	if err != nil {
+		t.Fatal(err)
+	}
+	manager := policy.NewManager(verifier)
+	bundle, err := policy.Sign(domain.PolicyBundle{
+		BundleID:  "bundle-integration",
+		Scope:     domain.PolicyScope{Tenant: "tenant-1", Agent: "agent:demo"},
+		Version:   "policy-integration-1",
+		ExpiresAt: now.Add(time.Hour),
+		Policy: json.RawMessage(`{
+			"default_decision":"BLOCK",
+			"rules":[
+				{"capability":"provider.generate","provider":"openai","decision":"ALLOW"},
+				{"capability":"provider.generate","provider":"anthropic","decision":"ESCALATE"},
+				{"capability":"provider.generate","provider":"banned","decision":"ALLOW"},
+				{"capability":"provider.generate","provider":"banned","decision":"BLOCK","reason_code":"PROVIDER_BANNED"}
+			]
+		}`),
+	}, privateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.Activate(bundle, now); err != nil {
+		t.Fatal(err)
+	}
+	sink, _ := audit.NewMemorySink(10)
+	nextID := 0
+	enforcement, err := engine.New(engine.Options{
+		Policies: manager,
+		Audit:    sink,
+		Clock:    func() time.Time { return now },
+		IDs: func() string {
+			nextID++
+			return fmt.Sprintf("id-%d", nextID)
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler := New(Options{
+		Evaluator: enforcement,
+		Ready:     func() bool { return manager.Ready(now) },
+		ActivePolicy: func() (domain.ActivePolicyVersion, bool) {
+			return manager.Metadata(now)
+		},
+	})
+
+	tests := []struct {
+		name       string
+		agent      string
+		provider   string
+		decision   domain.Decision
+		reasonCode string
+	}{
+		{name: "allow", agent: "agent:demo", provider: "openai", decision: domain.DecisionAllow, reasonCode: "POLICY_ALLOW"},
+		{name: "escalate", agent: "agent:demo", provider: "anthropic", decision: domain.DecisionEscalate, reasonCode: "POLICY_REVIEW_REQUIRED"},
+		{name: "deny overrides broad allow", agent: "agent:demo", provider: "banned", decision: domain.DecisionBlock, reasonCode: "PROVIDER_BANNED"},
+		{name: "identity mismatch", agent: "agent:attacker", provider: "openai", decision: domain.DecisionBlock, reasonCode: "IDENTITY_SCOPE_MISMATCH"},
+	}
+
+	for index, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			body := fmt.Sprintf(`{
+				"request_id":"req-%d",
+				"agent_claim":%q,
+				"capability_request":{"capability":"provider.generate","provider":%q},
+				"input":{},
+				"context":{}
+			}`, index, test.agent, test.provider)
+			request := httptest.NewRequest(http.MethodPost, "/v1alpha1/execution/intent", strings.NewReader(body))
+			request.Header.Set("Content-Type", "application/json")
+			response := httptest.NewRecorder()
+			handler.ServeHTTP(response, request)
+			if response.Code != http.StatusOK {
+				t.Fatalf("status = %d: %s", response.Code, response.Body.String())
+			}
+			var envelope domain.DecisionEnvelope
+			if err := json.NewDecoder(response.Body).Decode(&envelope); err != nil {
+				t.Fatal(err)
+			}
+			if envelope.Decision != test.decision || envelope.ReasonCode != test.reasonCode {
+				t.Fatalf("decision = %#v", envelope)
+			}
+			if envelope.Allowed != (test.decision == domain.DecisionAllow) {
+				t.Fatalf("allowed = %t for decision %s", envelope.Allowed, envelope.Decision)
+			}
+		})
+	}
+
+	if len(sink.Events()) != len(tests) {
+		t.Fatalf("audit events = %d, want %d", len(sink.Events()), len(tests))
+	}
+}

--- a/services/sidecar/internal/policy/bundle.go
+++ b/services/sidecar/internal/policy/bundle.go
@@ -1,0 +1,290 @@
+package policy
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aegisora-ai/aegisora/services/sidecar/internal/domain"
+)
+
+const (
+	digestPrefix    = "sha256:"
+	signaturePrefix = "ed25519:"
+)
+
+type Rule struct {
+	AgentClaim string          `json:"agent_claim,omitempty"`
+	Capability string          `json:"capability,omitempty"`
+	Provider   string          `json:"provider,omitempty"`
+	Model      string          `json:"model,omitempty"`
+	Route      string          `json:"route,omitempty"`
+	Decision   domain.Decision `json:"decision"`
+	ReasonCode string          `json:"reason_code,omitempty"`
+	Risk       *domain.Risk    `json:"risk,omitempty"`
+}
+
+type Document struct {
+	DefaultDecision domain.Decision `json:"default_decision,omitempty"`
+	Rules           []Rule          `json:"rules"`
+}
+
+type Snapshot struct {
+	Bundle   domain.PolicyBundle
+	Document Document
+}
+
+type Ed25519Verifier struct {
+	publicKey ed25519.PublicKey
+}
+
+func NewEd25519Verifier(encodedPublicKey string) (*Ed25519Verifier, error) {
+	publicKey, err := base64.StdEncoding.DecodeString(strings.TrimSpace(encodedPublicKey))
+	if err != nil {
+		return nil, fmt.Errorf("decode policy public key: %w", err)
+	}
+	if len(publicKey) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("policy public key must be %d bytes", ed25519.PublicKeySize)
+	}
+	return &Ed25519Verifier{publicKey: ed25519.PublicKey(append([]byte(nil), publicKey...))}, nil
+}
+
+func (verifier *Ed25519Verifier) Verify(bundle domain.PolicyBundle) error {
+	wantDigest, err := Digest(bundle)
+	if err != nil {
+		return err
+	}
+	if bundle.Digest != wantDigest {
+		return errors.New("policy bundle digest mismatch")
+	}
+
+	encodedSignature := strings.TrimPrefix(bundle.Signature, signaturePrefix)
+	signature, err := base64.StdEncoding.DecodeString(encodedSignature)
+	if err != nil {
+		return fmt.Errorf("decode policy signature: %w", err)
+	}
+	if !ed25519.Verify(verifier.publicKey, []byte(wantDigest), signature) {
+		return errors.New("policy bundle signature mismatch")
+	}
+	return nil
+}
+
+func Digest(bundle domain.PolicyBundle) (string, error) {
+	var normalizedPolicy any
+	decoder := json.NewDecoder(bytes.NewReader(bundle.Policy))
+	decoder.UseNumber()
+	if err := decoder.Decode(&normalizedPolicy); err != nil {
+		return "", fmt.Errorf("decode policy for digest: %w", err)
+	}
+	if normalizedPolicy == nil {
+		return "", errors.New("policy must be a JSON object")
+	}
+
+	payload := struct {
+		BundleID  string             `json:"bundle_id"`
+		Scope     domain.PolicyScope `json:"scope"`
+		Version   string             `json:"version"`
+		ExpiresAt time.Time          `json:"expires_at"`
+		Policy    any                `json:"policy"`
+	}{
+		BundleID:  bundle.BundleID,
+		Scope:     bundle.Scope,
+		Version:   bundle.Version,
+		ExpiresAt: bundle.ExpiresAt.UTC(),
+		Policy:    normalizedPolicy,
+	}
+
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("encode policy digest payload: %w", err)
+	}
+	sum := sha256.Sum256(encoded)
+	return digestPrefix + hex.EncodeToString(sum[:]), nil
+}
+
+func EncodePublicKey(publicKey ed25519.PublicKey) string {
+	return base64.StdEncoding.EncodeToString(publicKey)
+}
+
+func Sign(bundle domain.PolicyBundle, privateKey ed25519.PrivateKey) (domain.PolicyBundle, error) {
+	if len(privateKey) != ed25519.PrivateKeySize {
+		return domain.PolicyBundle{}, fmt.Errorf("policy private key must be %d bytes", ed25519.PrivateKeySize)
+	}
+	digest, err := Digest(bundle)
+	if err != nil {
+		return domain.PolicyBundle{}, err
+	}
+	bundle.Digest = digest
+	bundle.Signature = signaturePrefix + base64.StdEncoding.EncodeToString(ed25519.Sign(privateKey, []byte(digest)))
+	return bundle, nil
+}
+
+func LoadFile(path string) (domain.PolicyBundle, error) {
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return domain.PolicyBundle{}, fmt.Errorf("read policy bundle: %w", err)
+	}
+
+	var bundle domain.PolicyBundle
+	decoder := json.NewDecoder(bytes.NewReader(contents))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&bundle); err != nil {
+		return domain.PolicyBundle{}, fmt.Errorf("decode policy bundle: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err == nil {
+		return domain.PolicyBundle{}, errors.New("policy bundle file must contain exactly one JSON object")
+	} else if !errors.Is(err, io.EOF) {
+		return domain.PolicyBundle{}, fmt.Errorf("decode trailing policy bundle data: %w", err)
+	}
+	return bundle, nil
+}
+
+func compile(bundle domain.PolicyBundle) (Document, error) {
+	if len(bundle.Policy) == 0 {
+		return Document{}, errors.New("policy must be an object")
+	}
+
+	var document Document
+	decoder := json.NewDecoder(bytes.NewReader(bundle.Policy))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&document); err != nil {
+		return Document{}, fmt.Errorf("decode policy document: %w", err)
+	}
+	if document.Rules == nil {
+		return Document{}, errors.New("policy.rules must be an array")
+	}
+	if document.DefaultDecision == "" {
+		document.DefaultDecision = domain.DecisionBlock
+	}
+	if !document.DefaultDecision.Valid() {
+		return Document{}, fmt.Errorf("invalid default decision %q", document.DefaultDecision)
+	}
+	for index, rule := range document.Rules {
+		if !rule.Decision.Valid() {
+			return Document{}, fmt.Errorf("policy.rules[%d] has invalid decision %q", index, rule.Decision)
+		}
+		if rule.Risk != nil && (rule.Risk.Score < 0 || rule.Risk.Score > 100) {
+			return Document{}, fmt.Errorf("policy.rules[%d].risk.score must be between 0 and 100", index)
+		}
+	}
+	return document, nil
+}
+
+type Manager struct {
+	mu       sync.RWMutex
+	verifier *Ed25519Verifier
+	active   *Snapshot
+	seen     map[string]string
+}
+
+func NewManager(verifier *Ed25519Verifier) *Manager {
+	return &Manager{
+		verifier: verifier,
+		seen:     make(map[string]string),
+	}
+}
+
+func (manager *Manager) Activate(bundle domain.PolicyBundle, now time.Time) error {
+	if manager.verifier == nil {
+		return errors.New("policy verifier is not configured")
+	}
+	if err := validateBundleIdentity(bundle); err != nil {
+		return err
+	}
+	if !bundle.ExpiresAt.After(now) {
+		return errors.New("policy bundle is expired")
+	}
+	if err := manager.verifier.Verify(bundle); err != nil {
+		return err
+	}
+	document, err := compile(bundle)
+	if err != nil {
+		return err
+	}
+
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	if priorDigest, exists := manager.seen[bundle.Version]; exists && priorDigest != bundle.Digest {
+		return fmt.Errorf("policy version %q was already observed with a different digest", bundle.Version)
+	}
+	manager.seen[bundle.Version] = bundle.Digest
+	snapshot := cloneSnapshot(Snapshot{Bundle: bundle, Document: document})
+	manager.active = &snapshot
+	return nil
+}
+
+func (manager *Manager) Active(now time.Time) (Snapshot, bool) {
+	manager.mu.RLock()
+	defer manager.mu.RUnlock()
+	if manager.active == nil || !manager.active.Bundle.ExpiresAt.After(now) {
+		return Snapshot{}, false
+	}
+	return cloneSnapshot(*manager.active), true
+}
+
+func cloneSnapshot(snapshot Snapshot) Snapshot {
+	cloned := snapshot
+	cloned.Bundle.Policy = append(json.RawMessage(nil), snapshot.Bundle.Policy...)
+	cloned.Document.Rules = make([]Rule, len(snapshot.Document.Rules))
+	for index, rule := range snapshot.Document.Rules {
+		cloned.Document.Rules[index] = rule
+		if rule.Risk != nil {
+			risk := *rule.Risk
+			risk.Signals = append([]string(nil), rule.Risk.Signals...)
+			cloned.Document.Rules[index].Risk = &risk
+		}
+	}
+	return cloned
+}
+
+func (manager *Manager) Ready(now time.Time) bool {
+	_, ready := manager.Active(now)
+	return ready
+}
+
+func (manager *Manager) Metadata(now time.Time) (domain.ActivePolicyVersion, bool) {
+	snapshot, ok := manager.Active(now)
+	if !ok {
+		return domain.ActivePolicyVersion{}, false
+	}
+	return domain.ActivePolicyVersion{
+		Version:   snapshot.Bundle.Version,
+		Digest:    snapshot.Bundle.Digest,
+		ExpiresAt: snapshot.Bundle.ExpiresAt.UTC(),
+	}, true
+}
+
+func validateBundleIdentity(bundle domain.PolicyBundle) error {
+	for field, value := range map[string]string{
+		"bundle_id":    bundle.BundleID,
+		"scope.tenant": bundle.Scope.Tenant,
+		"version":      bundle.Version,
+		"digest":       bundle.Digest,
+		"signature":    bundle.Signature,
+	} {
+		if strings.TrimSpace(value) == "" {
+			return fmt.Errorf("%s is required", field)
+		}
+	}
+	if bundle.ExpiresAt.IsZero() {
+		return errors.New("expires_at is required")
+	}
+	if !strings.HasPrefix(bundle.Digest, digestPrefix) {
+		return fmt.Errorf("digest must use %s", digestPrefix)
+	}
+	if !strings.HasPrefix(bundle.Signature, signaturePrefix) {
+		return fmt.Errorf("signature must use %s", signaturePrefix)
+	}
+	return nil
+}

--- a/services/sidecar/internal/policy/evaluator.go
+++ b/services/sidecar/internal/policy/evaluator.go
@@ -1,0 +1,107 @@
+package policy
+
+import (
+	"strings"
+
+	"github.com/aegisora-ai/aegisora/services/sidecar/internal/domain"
+)
+
+type Evaluation struct {
+	Decision   domain.Decision
+	ReasonCode string
+	Risk       domain.Risk
+}
+
+func Evaluate(snapshot Snapshot, intent domain.ExecutionIntent) Evaluation {
+	if snapshot.Bundle.Scope.Agent != "" && snapshot.Bundle.Scope.Agent != intent.AgentClaim {
+		return blocked("IDENTITY_SCOPE_MISMATCH")
+	}
+	if snapshot.Bundle.Scope.Capability != "" && snapshot.Bundle.Scope.Capability != intent.CapabilityRequest.Capability {
+		return blocked("CAPABILITY_SCOPE_MISMATCH")
+	}
+
+	var selected *Rule
+	for index := range snapshot.Document.Rules {
+		rule := &snapshot.Document.Rules[index]
+		if !matches(*rule, intent) {
+			continue
+		}
+		if selected == nil || precedence(rule.Decision) > precedence(selected.Decision) {
+			selected = rule
+		}
+	}
+
+	if selected == nil {
+		return Evaluation{
+			Decision:   snapshot.Document.DefaultDecision,
+			ReasonCode: defaultReason(snapshot.Document.DefaultDecision),
+			Risk:       defaultRisk(snapshot.Document.DefaultDecision),
+		}
+	}
+
+	reason := strings.TrimSpace(selected.ReasonCode)
+	if reason == "" {
+		reason = defaultReason(selected.Decision)
+	}
+	risk := defaultRisk(selected.Decision)
+	if selected.Risk != nil {
+		risk = *selected.Risk
+	}
+	return Evaluation{Decision: selected.Decision, ReasonCode: reason, Risk: risk}
+}
+
+func matches(rule Rule, intent domain.ExecutionIntent) bool {
+	request := intent.CapabilityRequest
+	return match(rule.AgentClaim, intent.AgentClaim) &&
+		match(rule.Capability, request.Capability) &&
+		match(rule.Provider, request.Provider) &&
+		match(rule.Model, request.Model) &&
+		match(rule.Route, request.Route)
+}
+
+func match(expected string, actual string) bool {
+	return expected == "" || expected == actual
+}
+
+func precedence(decision domain.Decision) int {
+	switch decision {
+	case domain.DecisionBlock:
+		return 3
+	case domain.DecisionEscalate:
+		return 2
+	case domain.DecisionAllow:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func defaultReason(decision domain.Decision) string {
+	switch decision {
+	case domain.DecisionAllow:
+		return "POLICY_ALLOW"
+	case domain.DecisionEscalate:
+		return "POLICY_REVIEW_REQUIRED"
+	default:
+		return "POLICY_BLOCK"
+	}
+}
+
+func defaultRisk(decision domain.Decision) domain.Risk {
+	switch decision {
+	case domain.DecisionAllow:
+		return domain.Risk{Score: 0, Level: "LOW"}
+	case domain.DecisionEscalate:
+		return domain.Risk{Score: 50, Level: "MEDIUM"}
+	default:
+		return domain.Risk{Score: 100, Level: "HIGH"}
+	}
+}
+
+func blocked(reason string) Evaluation {
+	return Evaluation{
+		Decision:   domain.DecisionBlock,
+		ReasonCode: reason,
+		Risk:       domain.Risk{Score: 100, Level: "HIGH"},
+	}
+}

--- a/services/sidecar/internal/policy/policy_test.go
+++ b/services/sidecar/internal/policy/policy_test.go
@@ -1,0 +1,141 @@
+package policy
+
+import (
+	"crypto/ed25519"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/aegisora-ai/aegisora/services/sidecar/internal/domain"
+)
+
+var testPrivateKey = ed25519.NewKeyFromSeed([]byte("0123456789abcdef0123456789abcdef"))
+var testPublicKey = testPrivateKey.Public().(ed25519.PublicKey)
+
+func signedBundle(t *testing.T, policyJSON string) domain.PolicyBundle {
+	t.Helper()
+	bundle := domain.PolicyBundle{
+		BundleID: "bundle-1",
+		Scope: domain.PolicyScope{
+			Tenant: "tenant-1",
+			Agent:  "agent:demo",
+		},
+		Version:   "policy-1",
+		ExpiresAt: time.Now().Add(time.Hour).UTC(),
+		Policy:    json.RawMessage(policyJSON),
+	}
+	bundle, err := Sign(bundle, testPrivateKey)
+	if err != nil {
+		t.Fatalf("Sign(): %v", err)
+	}
+	return bundle
+}
+
+func TestManagerActivatesValidSignedBundle(t *testing.T) {
+	verifier, err := NewEd25519Verifier(EncodePublicKey(testPublicKey))
+	if err != nil {
+		t.Fatal(err)
+	}
+	manager := NewManager(verifier)
+	bundle := signedBundle(t, `{"rules":[{"capability":"provider.generate","decision":"ALLOW"}]}`)
+
+	if err := manager.Activate(bundle, time.Now()); err != nil {
+		t.Fatalf("Activate(): %v", err)
+	}
+	if !manager.Ready(time.Now()) {
+		t.Fatal("manager must be ready")
+	}
+	metadata, ok := manager.Metadata(time.Now())
+	if !ok || metadata.Version != bundle.Version || metadata.Digest != bundle.Digest {
+		t.Fatalf("Metadata() = %#v, %t", metadata, ok)
+	}
+}
+
+func TestManagerRejectsTamperingAndExpiry(t *testing.T) {
+	verifier, _ := NewEd25519Verifier(EncodePublicKey(testPublicKey))
+	manager := NewManager(verifier)
+
+	tampered := signedBundle(t, `{"rules":[{"decision":"ALLOW"}]}`)
+	tampered.Policy = json.RawMessage(`{"rules":[{"decision":"BLOCK"}]}`)
+	if err := manager.Activate(tampered, time.Now()); err == nil {
+		t.Fatal("tampered bundle must be rejected")
+	}
+
+	expired := signedBundle(t, `{"rules":[]}`)
+	expired.ExpiresAt = time.Now().Add(-time.Minute)
+	expired, _ = Sign(expired, testPrivateKey)
+	if err := manager.Activate(expired, time.Now()); err == nil {
+		t.Fatal("expired bundle must be rejected")
+	}
+}
+
+func TestManagerSnapshotCannotBeMutatedByCaller(t *testing.T) {
+	verifier, _ := NewEd25519Verifier(EncodePublicKey(testPublicKey))
+	manager := NewManager(verifier)
+	bundle := signedBundle(t, `{"rules":[{"decision":"ALLOW","risk":{"score":1,"signals":["original"]}}]}`)
+	if err := manager.Activate(bundle, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+
+	bundle.Policy[0] = '['
+	first, ok := manager.Active(time.Now())
+	if !ok {
+		t.Fatal("active snapshot missing")
+	}
+	first.Document.Rules[0].Decision = domain.DecisionBlock
+	first.Document.Rules[0].Risk.Signals[0] = "mutated"
+	first.Bundle.Policy[0] = '['
+
+	second, ok := manager.Active(time.Now())
+	if !ok {
+		t.Fatal("active snapshot missing after mutation attempt")
+	}
+	if second.Document.Rules[0].Decision != domain.DecisionAllow ||
+		second.Document.Rules[0].Risk.Signals[0] != "original" ||
+		second.Bundle.Policy[0] != '{' {
+		t.Fatalf("active snapshot was mutated: %#v", second)
+	}
+}
+
+func TestEvaluateUsesDenyOverrides(t *testing.T) {
+	bundle := signedBundle(t, `{
+		"default_decision":"BLOCK",
+		"rules":[
+			{"capability":"provider.generate","decision":"ALLOW"},
+			{"capability":"provider.generate","provider":"blocked-provider","decision":"BLOCK","reason_code":"PROVIDER_DENIED"}
+		]
+	}`)
+	document, err := compile(bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot := Snapshot{Bundle: bundle, Document: document}
+	intent := domain.ExecutionIntent{
+		RequestID:  "req-1",
+		AgentClaim: "agent:demo",
+		CapabilityRequest: domain.CapabilityRequest{
+			Capability: "provider.generate",
+			Provider:   "blocked-provider",
+		},
+		Input:   map[string]json.RawMessage{},
+		Context: map[string]json.RawMessage{},
+	}
+
+	result := Evaluate(snapshot, intent)
+	if result.Decision != domain.DecisionBlock || result.ReasonCode != "PROVIDER_DENIED" {
+		t.Fatalf("Evaluate() = %#v", result)
+	}
+}
+
+func TestEvaluateBlocksScopeMismatch(t *testing.T) {
+	bundle := signedBundle(t, `{"rules":[{"decision":"ALLOW"}]}`)
+	document, _ := compile(bundle)
+	intent := domain.ExecutionIntent{
+		AgentClaim:        "agent:attacker",
+		CapabilityRequest: domain.CapabilityRequest{Capability: "provider.generate"},
+	}
+	result := Evaluate(Snapshot{Bundle: bundle, Document: document}, intent)
+	if result.Decision != domain.DecisionBlock || result.ReasonCode != "IDENTITY_SCOPE_MISMATCH" {
+		t.Fatalf("Evaluate() = %#v", result)
+	}
+}


### PR DESCRIPTION
## Summary

Introduce the first Go 1.27 decision-sidecar vertical slice for the Aegisora `v1alpha1` governance contract, rebased onto the latest upstream `main` after Aegisora `2.0.0` and its delegation/collaboration hardening.

This PR intentionally establishes a decision service before the controlled-proxy boundary. It validates execution intents, verifies and atomically activates signed policy snapshots, evaluates deterministic `ALLOW` / `BLOCK` / `ESCALATE` outcomes, records correlated audit events, and exposes policy-backed readiness.

The upstream `v1alpha1` OpenAPI contract and semantic fixture corpus remain unchanged, so the sidecar is contract-compatible. The documentation now also accounts for the canonical `ToolRegistry`, scoped single-use authorization receipts, correlation integrity, delegated-agent capabilities, scope containment, and collaboration ownership boundaries in the current runtime.

## What changed

- add the Go 1.27 sidecar service, Docker build, Makefile, local signing tools, examples, and documentation;
- implement strict `v1alpha1` domain validation and load the repository's shared semantic fixtures in Go tests;
- implement Ed25519 policy signing and verification, canonical SHA-256 digests, expiry checks, scope checks, immutable snapshots, and atomic activation;
- implement a deliberately small deny-overrides policy dialect (`BLOCK > ESCALATE > ALLOW`);
- add bounded request idempotency with conflicting-payload rejection and concurrency-safe same-ID serialization;
- bind cached decisions to the active policy version and digest so policy replacement, removal, or expiry forces reevaluation;
- deep-copy cached risk signals and in-memory audit payloads so callers cannot mutate stored decisions or evidence;
- add strict JSON, body-size, content-type, header-timeout, and total request-read-timeout handling;
- add health, readiness, and active-policy metadata endpoints;
- add Go 1.27 CI and release verification;
- make the security-readiness workflow release-independent by deriving the expected public-package version from the canonical package manifest and scanning only Git-tracked repository content;
- update the repository investigation and architecture proposal for the current 2.0 runtime authority, delegation, and collaboration model.

## Security behavior

- no valid unexpired policy means not-ready and fail-closed decisions;
- unsigned, modified, expired, or incorrectly scoped bundles cannot activate;
- `allowed` is mechanically derived from `decision == ALLOW`;
- duplicate request IDs replay only for identical intent payloads under the same active policy version and digest;
- policy changes invalidate compatible cache entries, preventing a stale cached `ALLOW` from surviving loss of authorization;
- a request-ID payload conflict returns `BLOCK`;
- broad allow rules cannot override a matching block rule;
- audit append failure prevents a successful decision response;
- bounded reads protect the local HTTP surface from oversized and indefinitely slow request bodies.

## Verification

- `make fmt-check vet test-race build tools`
- `npx --yes pnpm@11.20.0 verify`
- all 85 TypeScript runtime tests pass, including delegation, expiry, revocation, scope-containment, sibling-isolation, collaboration-ownership, governance-boundary, and correlation-integrity traces
- `git diff --check`

## Deliberate follow-up PRs

This PR does not claim a complete production enforcement boundary. The documented next slices are:

1. controlled upstream proxying with strict signed route selection and zero-side-effect adversarial tests;
2. authenticated workload identity over a Unix-domain-socket/local transport;
3. FastAPI policy polling, rollback protection, key rotation, and last-known-good persistence;
4. durable audit WAL/export and escalation approval flow;
5. TypeScript distributed mode with no ungoverned fallback.
